### PR TITLE
Fix namespace delete command in cleanup-helm-release.sh script

### DIFF
--- a/scripts/pulsar/cleanup_helm_release.sh
+++ b/scripts/pulsar/cleanup_helm_release.sh
@@ -73,7 +73,7 @@ release=${release:-pulsar-dev}
 
 function delete_namespace() {
     if [[ "${delete_namespace}" == "true" ]]; then
-        kubectl create namespace ${namespace}
+        kubectl delete namespace ${namespace}
     fi
 }
 


### PR DESCRIPTION
### Motivation

While making use of the scripts provided in this repo to prepare helm releases, I noticed that providing the ```-d``` flag (delete namespace) for the ```./scripts/pulsar/cleanup_helm_release.sh``` would always fail claiming that the **namespace already exists**. Upon closer examination, I noticed that the kubectl command to delete the provided namespace is actually attempting to create it instead.

### Modifications

I've gone ahead and made the corresponding modification on the script to delete the namespace (went from ```kubectl create namespace ${namespace}``` to ```kubectl delete namespace ${namespace}```).

### Verifying this change

I'm not sure what possible verifications I can provide for this PR. Please advise.