### PR TITLE
Decouple credentials from key secrets generation

### DIFF
--- a/charts/pulsar/templates/grafana-admin-secret.yaml
+++ b/charts/pulsar/templates/grafana-admin-secret.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if or .Values.monitoring.grafana .Values.extra.monitoring }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.grafana.component }}
+type: Opaque
+stringData:
+  {{- if .Values.grafana.admin}}
+  GRAFANA_ADMIN_PASSWORD: {{ .Values.grafana.admin.password | default "pulsar" }}
+  GRAFANA_ADMIN_USER: {{ .Values.grafana.admin.user | default "pulsar" }}
+  {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana-deployment.yaml
@@ -74,11 +74,11 @@ spec:
         - name: GRAFANA_ADMIN_USER
           valueFrom:
             secretKeyRef:
-              name: "{{ template "pulsar.fullname" . }}-admin-secret"
-              key: USER
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
+              key: GRAFANA_ADMIN_USER
         - name: GRAFANA_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: "{{ template "pulsar.fullname" . }}-admin-secret"
-              key: PASSWORD
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
+              key: GRAFANA_ADMIN_PASSWORD
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -864,6 +864,9 @@ grafana:
     protocol: http
     path: /grafana
     port: 80
+  admin:
+    user: pulsar
+    password: pulsar
 
 ## Components Stack: pulsar_manager
 ## templates/pulsar-manager.yaml

--- a/scripts/pulsar/cleanup_helm_release.sh
+++ b/scripts/pulsar/cleanup_helm_release.sh
@@ -73,7 +73,7 @@ release=${release:-pulsar-dev}
 
 function delete_namespace() {
     if [[ "${delete_namespace}" == "true" ]]; then
-        kubectl create namespace ${namespace}
+        kubectl delete namespace ${namespace}
     fi
 }
 

--- a/scripts/pulsar/cleanup_helm_release.sh
+++ b/scripts/pulsar/cleanup_helm_release.sh
@@ -77,9 +77,6 @@ function delete_namespace() {
     fi
 }
 
-# delete the cc admin secrets
-kubectl delete -n ${namespace} secret ${release}-admin-secret
-
 # delete tokens
 kubectl get secrets -n ${namespace} | grep ${release}-token- | awk '{print $1}' | xargs kubectl delete secrets -n ${namespace}
 

--- a/scripts/pulsar/prepare_helm_release.sh
+++ b/scripts/pulsar/prepare_helm_release.sh
@@ -29,8 +29,6 @@ Options:
        -n,--namespace                   the k8s namespace to install the pulsar helm chart
        -k,--release                     the pulsar helm release name
        -s,--symmetric                   generate symmetric secret key. If not provided, an asymmetric pair of keys are generated.
-       --control-center-admin           the user name of control center administrator
-       --control-center-password        the password of control center administrator
        --pulsar-superusers              the superusers of pulsar cluster. a comma separated list of super users.
        -c,--create-namespace            flag to create k8s namespace.
 Usage:
@@ -61,16 +59,6 @@ case $key in
     shift
     shift
     ;;
-    --control-center-admin)
-    cc_admin="$2"
-    shift
-    shift
-    ;;
-    --control-center-password)
-    cc_password="$2"
-    shift
-    shift
-    ;;
     --pulsar-superusers)
     pulsar_superusers="$2"
     shift
@@ -94,15 +82,7 @@ done
 
 namespace=${namespace:-pulsar}
 release=${release:-pulsar-dev}
-cc_admin=${cc_admin:-pulsar}
-cc_password=${cc_password:-pulsar}
 pulsar_superusers=${pulsar_superusers:-"proxy-admin,broker-admin,admin"}
-
-function generate_cc_admin_credentials() {
-    local secret_name="${release}-admin-secret"
-    kubectl create secret generic ${secret_name} -n ${namespace} \
-        --from-literal="USER=${cc_admin}" --from-literal="PASSWORD=${cc_password}"
-}
 
 function do_create_namespace() {
     if [[ "${create_namespace}" == "true" ]]; then
@@ -111,9 +91,6 @@ function do_create_namespace() {
 }
 
 do_create_namespace
-
-echo "create the credentials for the admin user of control center (grafana & pulsar-manager)"
-generate_cc_admin_credentials
 
 extra_opts=""
 if [[ "${symmetric}" == "true" ]]; then
@@ -147,9 +124,5 @@ for user in "${superusers[@]}"
 do
     echo "    - '${user}':secret('${release}-token-${user}')"
 done
-echo
-
-echo "The credentials of the administrator of Control Center (Grafana & Pulsar Manager)"
-echo "is stored at secret '${release}-admin-secret"
 echo
 


### PR DESCRIPTION
Fixes #6 

### Motivation

As suggested here: https://pulsar.apache.org/docs/en/helm-deploy/#prepare-the-helm-release. The ```prepare_helm_release.sh``` script provided with this Helm chart can create a secret credentials resource and
> The username and password are used for logging into Grafana dashboard and Pulsar Manager.

However, I haven't been able to make use of such a feature for a number of reasons:

1. This secret doesn't seem to affect the ```pulsar-manager-deployment.yaml``` definition. Instead, the ```./templates/pulsar-manager-admin-secret.yaml``` seems to be the one providing the credentials for the pulsar manager (UI) (with the added possibility to overwrite via values.yaml at ```pulsar_manager.admin.user/password```).

2. Using the Pulsar chart as a dependency for an umbrella chart (this is currently my use case), will bring extra hassle that will make it very hard to have all resources follow the same naming structure, thus causing some resources to never be deployed successfully e.g.: ```./templates/grafana-deployment.yaml``` will complain that it couldn't find the secret created by the bash script. Attempting to fix this issue via the ```-k``` flag passed to the script will cause the JWT secret tokens to have a name that's unexpected by the broker, etc.

### Modifications

Decouple grafana credentials from pulsar manager via a new secret resource named ```./charts/pulsar/templates/grafana-admin-secret.yaml```.

Add credentials overriding via values.yaml in the same way as pulsar_manager (grafana.admin.user/password) & delete secret resource manipulation from bash scripts (cleaup_helm_release.sh & prepare_helm_release.sh)

### Verifying this change

- [x] Make sure that the change passes the CI checks.
