### PR TITLE
Support load balance source ip range

### DIFF
--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -40,4 +40,8 @@ spec:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.grafana.component }}
   sessionAffinity: None
+{{- if .Values.grafana.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.grafana.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -38,4 +38,8 @@ spec:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}
     component: {{ .Values.pulsar_manager.component }}
+{{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.pulsar_manager.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Grafana and pulsar manager now support restricting
the available IPs that can be used.

Note, this is my first experience with helm, so it may not be the most appropriate approach.

Fixes #984 / https://github.com/apache/pulsar/issues/6950

### Motivation

Supporting an "allow list" of valid IPs for hitting the public pulsar manager and grafana endpoints for additional security.

### Modifications

If no values are provided, do not omit `loadBalancerSourceRanges` in the generated yaml.

Otherwise, the values are omitted under `loadBalancerSourceRanges`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
