### PR TITLE
Use regular 2-2-2 BK client settings by default

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -599,8 +599,8 @@ broker:
       -XX:+UseG1GC
       -XX:MaxGCPauseMillis=10
       "
-    managedLedgerDefaultEnsembleSize: "3"
-    managedLedgerDefaultWriteQuorum: "3"
+    managedLedgerDefaultEnsembleSize: "2"
+    managedLedgerDefaultWriteQuorum: "2"
     managedLedgerDefaultAckQuorum: "2"
   ## Broker service
   ## templates/broker-service.yaml


### PR DESCRIPTION
### Motivation

Using write=3 and ack=2 leads to unbound memory usage in BK client when one bookie is slow or failing, so we should avoid it by default.