### PR TITLE
Removing reference to bastion pod

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -113,8 +113,6 @@ extra:
   dashboard: false
   # pulsar manager
   pulsar_manager: false
-  # Bastion pod for administrative commands
-  bastion: false
   # Monitoring stack (prometheus and grafana)
   monitoring: false
   # Configure Kubernetes runtime for Functions


### PR DESCRIPTION

### Motivation

Has otherwise been cleaned up in f64c396906e9f99999ec14bd3ac7336e6609a86a

Removing because it is unused and it caused me some confusion when the pulsar-admin as actually run from the toolset.

### Modifications

Removing a value which is never referenced.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
