### PR TITLE
Bump version of pulsar to 2.5.2

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -124,34 +124,34 @@ extra:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
     pullPolicy: IfNotPresent
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
     pullPolicy: IfNotPresent
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
     pullPolicy: IfNotPresent
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
     pullPolicy: IfNotPresent
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
     pullPolicy: IfNotPresent
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.5.2
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.6
+    tag: 0.0.8
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager


### PR DESCRIPTION
### Motivation

I was having some pulsar issues, so wanted to bump to pulsar 2.5.2 to see if it was more stable.

NOTE: With this setup I've noticed that the outbound message / throughput rates are no longer displayed.  Inbound is fine.
![image](https://user-images.githubusercontent.com/395523/83101962-d7bb5980-a0f6-11ea-86f2-a4cccae0df44.png)

### Modifications

- Upgrade apachepulsar/pulsar-all to 2.5.2
- Upgrade streamnative/apache-pulsar-grafana-dashboard-k8s to 0.0.8

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
