### PR TITLE
Remove newline from secret tokens generation

### DIFF
--- a/scripts/pulsar/generate_token.sh
+++ b/scripts/pulsar/generate_token.sh
@@ -98,7 +98,9 @@ function pulsar::jwt::generate_symmetric_token() {
     trap "test -f $tokentmpfile && rm $tokentmpfile" RETURN
     kubectl get -n ${namespace} secrets ${secret_name} -o jsonpath="{.data['SECRETKEY']}" | base64 --decode > ${tmpfile}
     ${PULSARCTL_BIN} token create -a HS256 --secret-key-file ${tmpfile} --subject ${role} 2&> ${tokentmpfile}
-    kubectl create secret generic ${token_name} -n ${namespace} --from-file="TOKEN=${tokentmpfile}" --from-literal="TYPE=symmetric"
+    newtokentmpfile=$(mktemp)
+    tr -d '\n' < ${tokentmpfile} > ${newtokentmpfile}
+    kubectl create secret generic ${token_name} -n ${namespace} --from-file="TOKEN=${newtokentmpfile}" --from-literal="TYPE=symmetric"
 }
 
 function pulsar::jwt::generate_asymmetric_token() {
@@ -111,7 +113,9 @@ function pulsar::jwt::generate_asymmetric_token() {
     trap "test -f $tokentmpfile && rm $tokentmpfile" RETURN
     kubectl get -n ${namespace} secrets ${secret_name} -o jsonpath="{.data['PRIVATEKEY']}" | base64 --decode > ${privatekeytmpfile}
     ${PULSARCTL_BIN} token create -a RS256 --private-key-file ${privatekeytmpfile} --subject ${role} 2&> ${tokentmpfile}
-    kubectl create secret generic ${token_name} -n ${namespace} --from-file="TOKEN=${tokentmpfile}" --from-literal="TYPE=asymmetric"
+    newtokentmpfile=$(mktemp)
+    tr -d '\n' < ${tokentmpfile} > ${newtokentmpfile}
+    kubectl create secret generic ${token_name} -n ${namespace} --from-file="TOKEN=${newtokentmpfile}" --from-literal="TYPE=asymmetric"
 }
 
 if [[ "${symmetric}" == "true" ]]; then


### PR DESCRIPTION
### Motivation

The secret resources generation was appending a newline at the end of the JWT token strings (```\n```). From my understanding, this is not an issue inside Pulsar likely because it trims the contents of the JWT programmatically. However, when setting pulsar as a sink destination for [Vector](https://vector.dev/) (vector produces messages into Pulsar), I noticed the token was always invalid due to this extra newline.

### Modifications

Remove newline from secret tokens generation by using the utility command tr. Granted, this is not the nicest way to go about it but given that the contents are JWT strings, it appears to do the job just fine while keeping everything else working (e.g.: producing/consuming as well as other components like Prometheus). Please advise if you have any concerns or suggestions.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
