### PR TITLE
Allow to change broker service account annotations

### DIFF
--- a/charts/pulsar/templates/broker-service-account.yaml
+++ b/charts/pulsar/templates/broker-service-account.yaml
@@ -26,4 +26,8 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}
+  annotations:
+{{- with .Values.broker.service_account.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -592,6 +592,10 @@ broker:
   pdb:
     usePolicy: true
     maxUnavailable: 1
+  ### Broker service account
+  ## templates/broker-service-account.yaml
+  service_account:
+    annotations: {}
 
 ## Pulsar: Functions Worker
 ## templates/function-worker-configmap.yaml


### PR DESCRIPTION
### Motivation

We need to be able to change annotation to inject AWS IAM role (EKS based deployment).
https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html

With 2.6.0 and this annotation change we were able to use Tiered Storage with S3 and EKS/IAM(OIDC).

e.g : 
```
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::66666:role/my-iam-role-with-s3-access
```
values.yaml
```
broker:
  service_account:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::66666:role/my-iam-role-with-s3-access
```
### Modifications

Added a value to allow to change annotations fro broker service account.
I've tried following style from other part of the code.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
