### PR TITLE
Remove double quotes from the environment variables

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -496,9 +496,7 @@ autorecovery:
   ##
   configData:
     BOOKIE_MEM: >
-      "
       -Xms64m -Xmx64m
-      "
 
 ## Pulsar Zookeeper metadata. The metadata will be deployed as
 ## soon as the last zookeeper node is reachable. The deployment


### PR DESCRIPTION
*Motivation*

Some of the environment variables still use double quotes. They result in the following

```bash
Could not find or load main class "
```

