### PR TITLE
Don't substitute environment variables

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -107,7 +107,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
-          bin/apply-config-from-env.py conf/bkenv.sh;
           {{- include "pulsar.autorecovery.zookeeper.tls.settings" . | nindent 10 }}
           bin/bookkeeper autorecovery
         ports:

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -132,8 +132,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
-          bin/apply-config-from-env.py conf/bkenv.sh;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           bin/pulsar bookie;
         ports:

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -164,7 +164,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/broker.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           bin/gen-yml-from-env.py conf/functions_worker.yml;
           echo "OK" > status;
           {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 10 }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -143,7 +143,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/proxy.conf &&
-          bin/apply-config-from-env.py conf/pulsar_env.sh &&
           echo "OK" > status &&
           bin/pulsar proxy
         ports:

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -86,7 +86,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/zookeeper.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           {{- include "pulsar.zookeeper.tls.settings" . | nindent 10 }}
           bin/generate-zookeeper-config.sh conf/zookeeper.conf;
           bin/pulsar zookeeper;


### PR DESCRIPTION
*Motivation*

environment variables are already taken by bash scripts. We don't need to substitute them.

