### PR TITLE
Issue-29: Bump missed out pulsar-image tags to 2.6.0

### DIFF
--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -48,7 +48,7 @@ bookkeeper:
   metadata:
     image:
       repository: apachepulsar/pulsar-all
-      tag: 2.5.0
+      tag: 2.6.0
 
 broker:
   replicaCount: 1
@@ -72,24 +72,24 @@ toolset:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
 
 pulsar_metadata:
   image:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -348,7 +348,7 @@ bookkeeper:
     image:
       # the image used for running `bookkeeper-cluster-initialize` job
       repository: apachepulsar/pulsar-all
-      tag: 2.5.0
+      tag: 2.6.0
       pullPolicy: IfNotPresent
     ## Set the resources used for running `bin/bookkeeper shell initnewcluster`
     ##
@@ -509,7 +509,7 @@ pulsar_metadata:
   image:
     # the image used for running `pulsar-cluster-initialize` job
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:

--- a/examples/values-one-node.yaml
+++ b/examples/values-one-node.yaml
@@ -24,10 +24,10 @@ affinity:
 images:
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
 
 # disable auto recovery
 components:

--- a/examples/values-pulsar.yaml
+++ b/examples/values-pulsar.yaml
@@ -20,31 +20,31 @@
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0
 
 bookkeeper:
   metadata:
     image:
       repository: apachepulsar/pulsar-all
-      tag: 2.5.0
+      tag: 2.6.0
 
 
 pulsar_metadata:
   image:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: 2.6.0


### PR DESCRIPTION
Fixes #29 

### Motivation

Bumped missed out pulsar-image tags to 2.6.0

### Modifications

Modified the following files:
1. .ci/clusters/values-pulsar-image.yaml
2. charts/pulsar/values.yaml
3. examples/values-one-node.yaml
4. examples/values-pulsar.yaml
