### PR TITLE
add targetport for grafana and manager service

### DIFF
--- a/charts/pulsar/templates/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana-service.yaml
@@ -34,7 +34,8 @@ spec:
   type: {{ .Values.grafana.service.type }}
   ports:
     - name: server
-      port: {{ .Values.grafana.port }}
+      port: {{ .Values.grafana.service.port }}
+      targetPort: {{ .Values.grafana.service.targetPort }}
       protocol: TCP
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -32,7 +32,8 @@ spec:
   type: {{ .Values.pulsar_manager.service.type }}
   ports:
     - name: server
-      port: {{ .Values.pulsar_manager.port }}
+      port: {{ .Values.pulsar_manager.service.port }}
+      targetPort: {{ .Values.pulsar_manager.service.targetPort }}
       protocol: TCP
   selector:
     app: {{ template "pulsar.name" . }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -803,7 +803,6 @@ grafana:
   annotations: {}
   tolerations: []
   gracePeriod: 30
-  port: 3000
   resources:
     requests:
       memory: 250Mi
@@ -813,6 +812,8 @@ grafana:
   ##
   service:
     type: LoadBalancer
+    port: 3000
+    targetPort: 3000
     annotations: {}
   plugins: []
   ## Grafana ingress
@@ -848,7 +849,6 @@ grafana:
 ##
 pulsar_manager:
   component: pulsar-manager
-  port: 9527
   replicaCount: 1
   # nodeSelector:
   # cloud.google.com/gke-nodepool: default-pool
@@ -873,6 +873,8 @@ pulsar_manager:
   ##
   service:
     type: LoadBalancer
+    port: 9527
+    targetPort: 9527
     annotations: {}
   admin:
     user: pulsar


### PR DESCRIPTION
### Motivation

A [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/) can map any incoming port to a targetPort. By default and for convenience, the targetPort is set to the same value as the port field.

This change will give the flexibility to change port without customizing the chart templates.

### Modifications

- move port under service in values file
- add targetPort for grafana and pulsar_manager service

### Verifying this change

- [x] Make sure that the change passes the CI checks.
