### PR TITLE
Add optional user provided zookeeper as metadata store for other components

### DIFF
--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -9,11 +9,16 @@ Define the pulsar zookeeper
 Define the pulsar zookeeper
 */}}
 {{- define "pulsar.zookeeper.connect" -}}
+{{$zk:=.Values.pulsar_metadata.userProvidedZookeepers}}
+{{- if and (not .Values.components.zookeeper) $zk }}
+{{- $zk -}}
+{{ else }}
 {{- if not (and .Values.tls.enabled .Values.tls.zookeeper.enabled) -}}
 {{ template "pulsar.zookeeper.service" . }}:{{ .Values.zookeeper.ports.client }}
 {{- end -}}
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled -}}
 {{ template "pulsar.zookeeper.service" . }}:{{ .Values.zookeeper.ports.clientTls }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -31,8 +31,8 @@ spec:
     spec:
       initContainers:
       - name: wait-zookeeper-ready
-        image: "{{ .Values.bookkeeper.metadata.image.repository }}:{{ .Values.bookkeeper.metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.bookkeeper.metadata.image.pullPolicy }}
+        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
+        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -41,8 +41,8 @@ spec:
             done;
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-init"
-        image: "{{ .Values.bookkeeper.metadata.image.repository }}:{{ .Values.bookkeeper.metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.bookkeeper.metadata.image.pullPolicy }}
+        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
+        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
       {{- if .Values.bookkeeper.metadata.resources }}
         resources:
 {{ toYaml .Values.bookkeeper.metadata.resources | indent 10 }}

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -36,9 +36,15 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
+            {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
+            until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
+              echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
+            done;
+            {{ else }}
             until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}; do
               sleep 3;
             done;
+            {{- end}}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-init"
         image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -86,9 +86,15 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
+            {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
+            until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
+              echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
+            done;
+            {{ else }}
             until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.fullname" . }}; do
               sleep 3;
             done;
+            {{- end}}
       # This init container will wait for at least one broker to be ready before
       # deploying the proxy
       - name: wait-broker-ready

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -48,9 +48,15 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
+            {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
+            until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
+              echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
+            done;
+            {{ else }}
             until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}; do
               sleep 3;
             done;
+            {{- end}}
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before initializing pulsar metadata
       - name: pulsar-bookkeeper-verify-clusterid

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -510,6 +510,11 @@ pulsar_metadata:
   # configurationStore:
   configurationStoreMetadataPrefix: ""
 
+  ## optional, you can provide your own zookeeper metadata store for other components
+  # to use this, you should explicit set components.zookeeper to false
+  #
+  # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
+
 ## Pulsar: Broker cluster
 ## templates/broker-statefulset.yaml
 ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -345,11 +345,6 @@ bookkeeper:
   ## BookKeeper Cluster Initialize
   ## templates/bookkeeper-cluster-initialize.yaml
   metadata:
-    image:
-      # the image used for running `bookkeeper-cluster-initialize` job
-      repository: apachepulsar/pulsar-all
-      tag: 2.6.0
-      pullPolicy: IfNotPresent
     ## Set the resources used for running `bin/bookkeeper shell initnewcluster`
     ##
     resources:


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

- Case
 I have a physical zk cluster and want configure bookkeeper & broker & proxy to use it.
 So I set [components.zookeeper](https://github.com/apache/pulsar-helm-chart/blob/8f9c1d126e5a92d4dbf62412687c9511cc306d99/charts/pulsar/values.yaml#L75) as false, and only found [pulsar.zookeeper.connect](https://github.com/apache/pulsar-helm-chart/blob/8f9c1d126e5a92d4dbf62412687c9511cc306d99/charts/pulsar/templates/_zookeeper.tpl#L11) to set my physical zk address.
But deploy stage was stucked in bookkeeper wait-zookeeper-ready container.

- Issue
 The [wait-zookeeper-ready initContainer](https://github.com/apache/pulsar-helm-chart/blob/8f9c1d126e5a92d4dbf62412687c9511cc306d99/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml#L33) in bookkeeper-cluster-initialize Job used spliced zk Service hosts to detect zk ready or not, other component init Job initContainer do the same thing. Actually, zk service are unreachable because I disabled zk component.

### Modifications

- Add optional `pulsar_metadata.userProvidedZookeepers` config for this case, and make component's init Job use user zk to detect liveness, instead of spliced Service hosts.

- Delete redundant image reference in bookkeeper init Job.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
