### PR TITLE
Add Ingress to Pulsar Proxy and Pulsar Manager

### DIFF
--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.proxy.ingress.enabled }}
+apiVersion: extensions/v1beta1                                                                                                                                                            
+kind: Ingress                                                                                                                                                                             
+metadata:                                                                                                                                                                                 
+  labels:                                                                                                                                                                                 
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+  annotations:                                                                                                                                                                            
+{{- with .Values.proxy.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+  namespace: {{ .Values.namespace }}
+spec:                                                                                                                                                                                     
+{{- if .Values.proxy.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.proxy.ingress.hostname }}
+      {{- with .Values.proxy.ingress.tls.secretName }}
+      secretName: {{ . }}
+      {{- end }}
+{{- end }}
+  rules:
+    - host: {{ required "proxy ingress hostname not provided" .Values.proxy.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.proxy.ingress.path }}
+            backend:
+              serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+              {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
+              servicePort: {{ .Values.proxy.ports.https }}
+              {{- else }}
+              servicePort: {{ .Values.proxy.ports.http }}
+              {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.pulsar_manager.ingress.enabled }}
+apiVersion: extensions/v1beta1                                                                                                                                                            
+kind: Ingress                                                                                                                                                                             
+metadata:                                                                                                                                                                                 
+  labels:                                                                                                                                                                                 
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+  annotations:                                                                                                                                                                            
+{{- with .Values.pulsar_manager.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+  namespace: {{ .Values.namespace }}
+spec:                                                                                                                                                                                     
+{{- if .Values.pulsar_manager.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.pulsar_manager.ingress.hostname }}
+      {{- with .Values.pulsar_manager.ingress.tls.secretName }}
+      secretName: {{ . }}
+      {{- end }}
+{{- end }}
+  rules:
+    - host: {{ required "pulsar_manager ingress hostname not provided" .Values.pulsar_manager.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.pulsar_manager.ingress.path }}
+            backend:
+              serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+              servicePort: {{ .Values.pulsar_manager.service.targetPort }}
+{{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -668,6 +668,21 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
+  ## Proxy ingress
+  ## templates/proxy-ingress.yaml
+  ##
+  ingress:
+    enabled: false
+    annotations: {}
+    tls:
+      enabled: false
+
+      ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
+      secretName: ""
+
+    ## Required if ingress is enabled
+    hostname: ""
+    path: "/"
   ## Proxy PodDisruptionBudget
   ## templates/proxy-pdb.yaml
   ##
@@ -876,6 +891,22 @@ pulsar_manager:
     port: 9527
     targetPort: 9527
     annotations: {}
+  ## Pulsar manager ingress
+  ## templates/pulsar-manager-ingress.yaml
+  ##
+  ingress:
+    enabled: false
+    annotations: {}
+    tls:
+      enabled: false
+
+      ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
+      secretName: ""
+
+    ## Required if ingress is enabled
+    hostname: ""
+    path: "/"
+
   admin:
     user: pulsar
     password: pulsar


### PR DESCRIPTION
### Motivation

We're hosting our Pulsar Cluster in kubernetes but most of the actual clients are running on a different infrastructure. To expose the pulsar proxy and the pulsar manager we need a ingress resource.

### Modifications

I've copied the dashboard-ingress.yaml and adjusted the variable references and added some logic to support TLS configurations.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
