### PR TITLE
Update grafana dashboard images version to 0.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Intellij
+.idea
+
+# Mac
+**/.DS_Store
+
+**/output
+**/~
+
+# charts
+.chart-packages/**
+.chart-index/**
+.vs/
+charts/**/*.tgz
+charts/**/*.lock
+
+PRIVATEKEY
+PUBLICKEY

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -151,7 +151,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.8
+    tag: 0.0.9
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Modifications

- Update grafana dashboard images version to 0.0.9
- Add `.gitignore` file

### Verifying this change

- [x] Make sure that the change passes the CI checks.
