### PR TITLE
Allow Grafana to work with a reverse proxy

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.6.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.6.1
+version: 2.6.0-1
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/grafana-configmap.yaml
+++ b/charts/pulsar/templates/grafana-configmap.yaml
@@ -17,15 +17,15 @@
 # under the License.
 #
 
+{{- if or .Values.monitoring.grafana .Values.extra.monitoring }}
 apiVersion: v1
-appVersion: "2.6.0"
-description: Apache Pulsar Helm chart for Kubernetes
-name: pulsar
-version: 2.6.1
-home: https://pulsar.apache.org
-sources:
-- https://github.com/apache/pulsar
-icon: http://pulsar.apache.org/img/pulsar.svg
-maintainers:
-- name: The Apache Pulsar Team
-  email: dev@pulsar.apache.org
+kind: ConfigMap
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.grafana.component }}
+data:
+{{ toYaml .Values.grafana.configData | indent 2 }}
+{{- end }}

--- a/charts/pulsar/templates/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana-deployment.yaml
@@ -62,6 +62,9 @@ spec:
         ports:
         - name: server
           containerPort: {{ .Values.grafana.service.targetPort }}
+        envFrom:
+        - configMapRef:
+            name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
         env:
         # for supporting apachepulsar/pulsar-grafana
         - name: PROMETHEUS_URL

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -151,7 +151,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.9
+    tag: 0.0.10
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager
@@ -856,16 +856,16 @@ grafana:
     targetPort: 3000
     annotations: {}
   plugins: []
+  ## Grafana configMap
+  ## templates/grafana-configmap.yaml
+  ##
+  configData: {}
   ## Grafana ingress
   ## templates/grafana-ingress.yaml
   ##
   ingress:
     enabled: false
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      # nginx.ingress.kubernetes.io/rewrite-target: /$1
-      # ingress.kubernetes.io/force-ssl-redirect: "true"
-      ingress.kubernetes.io/rewrite-target: /
+    annotations: {}
     labels: {}
 
     tls: []


### PR DESCRIPTION
### Motivation

Allow Grafana to be served from a sub path.  

### Modifications

- Added a config map to add extra environment variables to the grafana deployment. As the grafana image adds new features that require environment variables, this can be used to set them.
- Bumped the grafana image to allow a reverse proxy
- removed ingress annotations as they are specific to nginx, and to match all the other ingresses
- bumped the chart version as per the README 


Example values:
```
grafana:
  configData:
    GRAFANA_ROOT_URL: /pulsar/grafana
    GRAFANA_SERVE_FROM_SUB_PATH: "true"
  ingress:
      enabled: true
      port: 3000
      path: "/pulsar/grafana/?(.*)"
      annotations:
        nginx.ingress.kubernetes.io/rewrite-target: /$1
```
