### PR TITLE
Ingress optional hostname

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.6.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.6.0-3
+version: 2.6.0-4
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/grafana-ingress.yaml
+++ b/charts/pulsar/templates/grafana-ingress.yaml
@@ -39,12 +39,15 @@ spec:
 {{ toYaml .Values.grafana.ingress.tls | indent 4 }}
 {{- end }}
   rules:
-    - host: {{ required "Grafana ingress hostname not provided" .Values.grafana.ingress.hostname }}
-      http:
+    - http:
         paths:
         - path: {{ .Values.grafana.ingress.path }}
           backend:
             serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
             servicePort: {{ .Values.grafana.ingress.port }}
+      {{- if .Values.grafana.ingress.hostname }}
+      host: {{ .Values.grafana.ingress.hostname }}
+      {{- end }}
+      
   {{- end }}
   {{- end }}

--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -43,8 +43,7 @@ spec:
       {{- end }}
 {{- end }}
   rules:
-    - host: {{ required "proxy ingress hostname not provided" .Values.proxy.ingress.hostname }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.proxy.ingress.path }}
             backend:
@@ -54,4 +53,7 @@ spec:
               {{- else }}
               servicePort: {{ .Values.proxy.ports.http }}
               {{- end }}
+      {{- if .Values.proxy.ingress.hostname }}
+      host: {{ .Values.proxy.ingress.hostname }}
+      {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -43,11 +43,13 @@ spec:
       {{- end }}
 {{- end }}
   rules:
-    - host: {{ required "pulsar_manager ingress hostname not provided" .Values.pulsar_manager.ingress.hostname }}
-      http:
+    - http:
         paths:
           - path: {{ .Values.pulsar_manager.ingress.path }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.service.targetPort }}
+      {{- if .Values.pulsar_manager.ingress.hostname }}
+      host: {{ .Values.pulsar_manager.ingress.hostname }}
+      {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -732,7 +732,6 @@ proxy:
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
 
-    ## Required if ingress is enabled
     hostname: ""
     path: "/"
   ## Proxy PodDisruptionBudget
@@ -902,7 +901,6 @@ grafana:
 
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
     extraPaths: []
-    ## Required if ingress is enabled
     hostname: ""
     protocol: http
     path: /grafana
@@ -955,7 +953,6 @@ pulsar_manager:
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
 
-    ## Required if ingress is enabled
     hostname: ""
     path: "/"
 


### PR DESCRIPTION
Fixes #50 

### Motivation
The host option is not required to setup an ingress, so I made it an optional value
### Modifications

*Describe the modifications you've done.*
Made setting the host optional.

### Verifying this change

- [X] Make sure that the change passes the CI checks.
