### PR TITLE
anti-affinity rules refactor and default image tags

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-broker-tls.yaml
+++ b/.ci/clusters/values-broker-tls.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-function.yaml
+++ b/.ci/clusters/values-function.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-jwt-asymmetric.yaml
+++ b/.ci/clusters/values-jwt-asymmetric.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-jwt-symmetric.yaml
+++ b/.ci/clusters/values-jwt-symmetric.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-local-pv.yaml
+++ b/.ci/clusters/values-local-pv.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -27,8 +27,8 @@ volumes:
   persistence: false
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:
@@ -45,10 +45,6 @@ bookkeeper:
     diskUsageWarnThreshold: "0.999"
     PULSAR_PREFIX_diskUsageThreshold: "0.999"
     PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
-  metadata:
-    image:
-      repository: apachepulsar/pulsar-all
-      tag: 2.6.0
 
 broker:
   replicaCount: 1
@@ -70,6 +66,9 @@ toolset:
 # use pulsar image
 
 images:
+  pulsar_metadata:
+    repository: apachepulsar/pulsar-all
+    tag: 2.6.0
   zookeeper:
     repository: apachepulsar/pulsar-all
     tag: 2.6.0
@@ -86,10 +85,5 @@ images:
     repository: apachepulsar/pulsar-all
     tag: 2.6.0
   proxy:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.0
-
-pulsar_metadata:
-  image:
     repository: apachepulsar/pulsar-all
     tag: 2.6.0

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -27,8 +27,8 @@ volumes:
   local_storage: true
 
 # disabled AntiAffinity
-affinity:
-  anti_affinity: false
+anti_affinity:
+  enabled: false
 
 # disable auto recovery and pulsar manager
 components:

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.6.1"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.6.1-1
+version: 2.6.1-2
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -60,10 +60,12 @@ spec:
 {{- end }}
     {{- end }}
       affinity:
-        {{- if and .Values.affinity.anti_affinity .Values.autorecovery.affinity.anti_affinity}}
+        {{- if and .Values.anti_affinity.enabled .Values.autorecovery.anti_affinity.enabled }}
+        {{- $type := default .Values.anti_affinity.type .Values.autorecovery.anti_affinity.type }}
+        {{- $topologyKey := default .Values.anti_affinity.topologyKey .Values.autorecovery.anti_affinity.topologyKey }}
         podAntiAffinity:
-          {{ if eq .Values.autorecovery.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.autorecovery.affinity.type }}:
+          {{- if eq $type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          {{ $type }}:
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -78,9 +80,9 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.autorecovery.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $topologyKey }}
         {{ else }}
-          {{ .Values.autorecovery.affinity.type }}:
+          {{ $type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
@@ -93,11 +95,11 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.autorecovery.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $topologyKey }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.autorecovery.gracePeriod }}
@@ -105,8 +107,10 @@ spec:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before deploying the bookies
       - name: pulsar-bookkeeper-verify-clusterid
-        image: "{{ .Values.images.autorecovery.repository }}:{{ .Values.images.autorecovery.tag }}"
-        imagePullPolicy: {{ .Values.images.autorecovery.pullPolicy }}
+        {{- with .Values.images.autorecovery }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
         - >
@@ -118,8 +122,10 @@ spec:
         {{- include "pulsar.autorecovery.certs.volumeMounts" . | nindent 8 }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-        image: "{{ .Values.images.autorecovery.repository }}:{{ .Values.images.autorecovery.tag }}"
-        imagePullPolicy: {{ .Values.images.autorecovery.pullPolicy }}
+        {{- with .Values.images.autorecovery }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
       {{- if .Values.autorecovery.resources }}
         resources:
 {{ toYaml .Values.autorecovery.resources | indent 10 }}
@@ -141,4 +147,3 @@ spec:
       volumes:
       {{- include "pulsar.autorecovery.certs.volumes" . | nindent 6 }}
 {{- end }}
-

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -31,8 +31,10 @@ spec:
     spec:
       initContainers:
       - name: wait-zookeeper-ready
-        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
-        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
+        {{- with .Values.images.bookie }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -47,8 +49,10 @@ spec:
             {{- end}}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-init"
-        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
-        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
+        {{- with .Values.images.bookie }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
       {{- if .Values.bookkeeper.metadata.resources }}
         resources:
 {{ toYaml .Values.bookkeeper.metadata.resources | indent 10 }}

--- a/charts/pulsar/templates/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper-service.yaml
@@ -29,6 +29,7 @@ metadata:
   annotations:
 {{ toYaml .Values.bookkeeper.service.annotations | indent 4 }}
 spec:
+  publishNotReadyAddresses: {{ .Values.bookkeeper.service.publishNotReadyAddresses }}
   ports:
   - name: bookie
     port: {{ .Values.bookkeeper.ports.bookie }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -57,10 +57,12 @@ spec:
 {{ toYaml .Values.bookkeeper.tolerations | indent 8 }}
     {{- end }}
       affinity:
-        {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity}}
+        {{- if and .Values.anti_affinity.enabled .Values.bookkeeper.anti_affinity.enabled }}
+        {{- $type := default .Values.anti_affinity.type .Values.bookkeeper.anti_affinity.type }}
+        {{- $topologyKey := default .Values.anti_affinity.topologyKey .Values.bookkeeper.anti_affinity.topologyKey }}
         podAntiAffinity:
-          {{ if eq .Values.bookkeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.bookkeeper.affinity.type }}:
+          {{- if eq $type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          {{ $type }}:
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -75,9 +77,9 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.bookkeeper.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $topologyKey }}
         {{ else }}
-          {{ .Values.bookkeeper.affinity.type }}:
+          {{ $type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
@@ -90,11 +92,11 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.bookkeeper.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $topologyKey }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
@@ -102,8 +104,10 @@ spec:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before deploying the bookies
       - name: pulsar-bookkeeper-verify-clusterid
-        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
-        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
+        {{- with .Values.images.bookie }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
         # only reformat bookie if bookkeeper is running without persistence
@@ -116,8 +120,10 @@ spec:
         {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-        image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
-        imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
+        {{- with .Values.images.bookie }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         {{- if .Values.bookkeeper.probe.liveness.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -58,7 +58,9 @@ data:
   # support version >= 2.5.0
   PF_functionRuntimeFactoryConfigs_pulsarRootDir: {{ template "pulsar.home" . }}
   PF_kubernetesContainerFactory_pulsarRootDir: {{ template "pulsar.home" . }}
-  PF_functionRuntimeFactoryConfigs_pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
+  {{- with .Values.images.functions }}
+  PF_functionRuntimeFactoryConfigs_pulsarDockerImageName: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+  {{- end }}
   PF_functionRuntimeFactoryConfigs_submittingInsidePod: "true"
   PF_functionRuntimeFactoryConfigs_installUserCodeDependencies: "true"
   PF_functionRuntimeFactoryConfigs_jobNamespace: {{ .Values.namespace }}
@@ -74,7 +76,9 @@ data:
   PF_functionRuntimeFactoryConfigs_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
   PF_functionRuntimeFactoryConfigs_changeConfigMapNamespace: {{ .Values.namespace }}
   # support version < 2.5.0
-  PF_kubernetesContainerFactory_pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
+  {{- with .Values.images.functions }}
+  PF_kubernetesContainerFactory_pulsarDockerImageName: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+  {{- end }}
   PF_kubernetesContainerFactory_submittingInsidePod: "true"
   PF_kubernetesContainerFactory_installUserCodeDependencies: "true"
   PF_kubernetesContainerFactory_jobNamespace: {{ .Values.namespace }}
@@ -90,7 +94,7 @@ data:
   PF_kubernetesContainerFactory_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
   PF_kubernetesContainerFactory_changeConfigMapNamespace: {{ .Values.namespace }}
   {{- end }}
-  
+
   # prometheus needs to access /metrics endpoint
   webServicePort: "{{ .Values.broker.ports.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -58,10 +58,12 @@ spec:
 {{ toYaml .Values.broker.tolerations | indent 8 }}
     {{- end }}
       affinity:
-        {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
+        {{- if and .Values.anti_affinity.enabled .Values.broker.anti_affinity.enabled }}
+        {{- $type := default .Values.anti_affinity.type .Values.broker.anti_affinity.type }}
+        {{- $topologyKey := default .Values.anti_affinity.topologyKey .Values.broker.anti_affinity.topologyKey }}
         podAntiAffinity:
-          {{ if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.broker.affinity.type }}:
+          {{- if eq $type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          {{ $type }}:
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -76,9 +78,9 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.broker.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $topologyKey }}
         {{ else }}
-          {{ .Values.broker.affinity.type }}:
+          {{ $type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
@@ -91,11 +93,11 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.broker.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $topologyKey }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.broker.gracePeriod }}
@@ -103,8 +105,10 @@ spec:
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
-        image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
-        imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
+        {{- with .Values.images.broker }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -122,8 +126,10 @@ spec:
       # This init container will wait for bookkeeper to be ready before
       # deploying the broker
       - name: wait-bookkeeper-ready
-        image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
-        imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
+        {{- with .Values.images.broker }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >
@@ -148,8 +154,10 @@ spec:
         {{- include "pulsar.broker.certs.volumeMounts" . | nindent 10 }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-        image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
-        imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
+        {{- with .Values.images.broker }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         {{- if .Values.broker.probe.liveness.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/pulsar/templates/function-worker-configmap.yaml
+++ b/charts/pulsar/templates/function-worker-configmap.yaml
@@ -28,5 +28,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.functions.component }}
 data:
-  pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
+  {{- with .Values.images.functions }}
+  pulsarDockerImageName: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+  {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -57,10 +57,12 @@ spec:
 {{ toYaml .Values.proxy.tolerations | indent 8 }}
     {{- end }}
       affinity:
-        {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity}}
+        {{- if and .Values.anti_affinity.enabled .Values.proxy.anti_affinity.enabled }}
+        {{- $type := default .Values.anti_affinity.type .Values.proxy.anti_affinity.type }}
+        {{- $topologyKey := default .Values.anti_affinity.topologyKey .Values.proxy.anti_affinity.topologyKey }}
         podAntiAffinity:
-        {{ if eq .Values.proxy.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.proxy.affinity.type }}:
+        {{- if eq $type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          {{ $type }}:
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -75,9 +77,9 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.proxy.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $topologyKey }}
         {{ else }}
-          {{ .Values.proxy.affinity.type }}:
+          {{ $type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
@@ -90,11 +92,11 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.proxy.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $topologyKey }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}
@@ -102,8 +104,10 @@ spec:
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
-        image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
-        imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
+        {{- with .Values.images.proxy }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -119,8 +123,10 @@ spec:
       # This init container will wait for at least one broker to be ready before
       # deploying the proxy
       - name: wait-broker-ready
-        image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
-        imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
+        {{- with .Values.images.proxy }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -133,8 +139,10 @@ spec:
             done;
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-        image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
-        imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
+        {{- with .Values.images.proxy }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         {{- if .Values.proxy.probe.liveness.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -33,8 +33,10 @@ spec:
       initContainers:
       {{- if .Values.pulsar_metadata.configurationStore }}
       - name: wait-cs-ready
-        image: "{{ .Values.pulsar_metadata.image.repository }}:{{ .Values.pulsar_metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.pulsar_metadata.image.pullPolicy }}
+        {{- with .Values.images.pulsar_metadata }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -44,8 +46,10 @@ spec:
 
       {{- end }}
       - name: wait-zookeeper-ready
-        image: "{{ .Values.pulsar_metadata.image.repository }}:{{ .Values.pulsar_metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.pulsar_metadata.image.pullPolicy }}
+        {{- with .Values.images.pulsar_metadata }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-
@@ -61,8 +65,10 @@ spec:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before initializing pulsar metadata
       - name: pulsar-bookkeeper-verify-clusterid
-        image: "{{ .Values.pulsar_metadata.image.repository }}:{{ .Values.pulsar_metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.pulsar_metadata.image.pullPolicy }}
+        {{- with .Values.images.pulsar_metadata }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
         command: ["sh", "-c"]
         args:
         - >
@@ -78,8 +84,10 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_metadata.component }}"
-        image: "{{ .Values.pulsar_metadata.image.repository }}:{{ .Values.pulsar_metadata.image.tag }}"
-        imagePullPolicy: {{ .Values.pulsar_metadata.image.pullPolicy }}
+        {{- with .Values.images.pulsar_metadata }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
       {{- if .Values.pulsar_metadata.resources }}
         resources:
 {{ toYaml .Values.pulsar_metadata.resources | indent 10 }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -55,8 +55,10 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
-        image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
-        imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
+        {{- with .Values.images.broker }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
       {{- if .Values.toolset.resources }}
         resources:
 {{ toYaml .Values.toolset.resources | indent 10 }}

--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -30,6 +30,7 @@ metadata:
   annotations:
 {{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
 spec:
+  publishNotReadyAddresses: {{ .Values.zookeeper.service.publishNotReadyAddresses }}
   ports:
     - name: follower
       port: {{ .Values.zookeeper.ports.follower }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -54,10 +54,12 @@ spec:
 {{ toYaml .Values.zookeeper.tolerations | indent 8 }}
     {{- end }}
       affinity:
-        {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
+        {{- if and .Values.anti_affinity.enabled .Values.zookeeper.anti_affinity.enabled }}
+        {{- $type := default .Values.anti_affinity.type .Values.zookeeper.anti_affinity.type }}
+        {{- $topologyKey := default .Values.anti_affinity.topologyKey .Values.zookeeper.anti_affinity.topologyKey }}
         podAntiAffinity:
-          {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.zookeeper.affinity.type }}:
+          {{- if eq $type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          {{ $type }}:
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -72,9 +74,9 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.zookeeper.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ $topologyKey }}
         {{ else }}
-          {{ .Values.zookeeper.affinity.type }}:
+          {{ $type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
@@ -87,18 +89,20 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.zookeeper.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ $topologyKey }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-        image: "{{ .Values.images.zookeeper.repository }}:{{ .Values.images.zookeeper.tag }}"
-        imagePullPolicy: {{ .Values.images.zookeeper.pullPolicy }}
+        {{- with .Values.images.zookeeper }}
+        image: "{{ default $.Values.images.pulsar_default.repository .repository }}:{{ default $.Values.images.pulsar_default.tag .tag }}"
+        imagePullPolicy: {{ default $.Values.images.pulsar_default.pullPolicy .pullPolicy }}
+        {{- end }}
       {{- if .Values.zookeeper.resources }}
         resources:
 {{ toYaml .Values.zookeeper.resources | indent 10 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -61,18 +61,22 @@ volumes:
   # the local provisioner should be installed prior to enable local persistent volume
   local_storage: false
 
-## AntiAffinity
+## podAntiAffinity
 ##
-## Flag to enable and disable `AntiAffinity` for all components.
-## This is a global setting that is applied to all components.
-## If you need to disable AntiAffinity for a component, you can set
-## the `affinity.anti_affinity` settings to `false` for that component.
-affinity:
-  anti_affinity: true
-  # Set the anti affinity type. Valid values: 
+## Sets podAntiAffinity rules for statefulSets
+anti_affinity:
+  # Flag to enable and disable `AntiAffinity` for all components.
+  # This is a global setting that is applied to all components.
+  # If you need to disable AntiAffinity for a component, you can set
+  # the `anti_affinity.enabled` settings to `false` for that component.
+  enabled: true
+  # Set the anti affinity topologyKey.
+  # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+  topologyKey: kubernetes.io/hostname
+  # Set the anti affinity type. Valid values:
   # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
   # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-  type: requiredDuringSchedulingIgnoredDuringExecution 
+  type: requiredDuringSchedulingIgnoredDuringExecution
 
 ## Components
 ##
@@ -129,29 +133,33 @@ extra:
 ##
 ## Control what images to use for each component
 images:
+  pulsar_default:
+    repository: apachepulsar/pulsar-all
+    tag: 2.6.1
+    pullPolicy: IfNotPresent
   zookeeper:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
+    repository:
+    tag:
+    pullPolicy:
   bookie:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
+    repository:
+    tag:
+    pullPolicy:
   autorecovery:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
+    repository:
+    tag:
+    pullPolicy:
   broker:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
+    repository:
+    tag:
+    pullPolicy:
   proxy:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
+    repository:
+    tag:
+    pullPolicy:
   functions:
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
+    repository:
+    tag:
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2
@@ -290,12 +298,15 @@ zookeeper:
       failureThreshold: 30
       initialDelaySeconds: 10
       periodSeconds: 30
-  affinity:
-    anti_affinity: true
-    # Set the anti affinity type. Valid values: 
+  anti_affinity:
+    enabled: true
+    # Set the anti affinity topologyKey.
+    # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+    topologyKey:
+    # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-    type: requiredDuringSchedulingIgnoredDuringExecution 
+    type:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8000"
@@ -345,7 +356,7 @@ zookeeper:
   ##
   service:
     annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    publishNotReadyAddresses: true
   ## Zookeeper PodDisruptionBudget
   ## templates/zookeeper-pdb.yaml
   ##
@@ -400,12 +411,15 @@ bookkeeper:
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 30
-  affinity:
-    anti_affinity: true
-    # Set the anti affinity type. Valid values: 
+  anti_affinity:
+    enabled: true
+    # Set the anti affinity topologyKey.
+    # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+    topologyKey:
+    # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-    type: requiredDuringSchedulingIgnoredDuringExecution 
+    type:
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -485,7 +499,7 @@ bookkeeper:
   ##
   service:
     annotations:
-      publishNotReadyAddresses: "true"
+    publishNotReadyAddresses: true
   ## Bookkeeper PodDisruptionBudget
   ## templates/bookkeeper-pdb.yaml
   ##
@@ -505,14 +519,17 @@ autorecovery:
     http: 8000
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
-  affinity:
-    anti_affinity: true
-    # Set the anti affinity type. Valid values: 
+  anti_affinity:
+    enabled: true
+    # Set the anti affinity topologyKey.
+    # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+    topologyKey:
+    # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-    type: requiredDuringSchedulingIgnoredDuringExecution 
+    type:
   annotations: {}
-  # tolerations: []
+  tolerations: []
   gracePeriod: 30
   resources:
     requests:
@@ -584,12 +601,15 @@ broker:
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 10
-  affinity:
-    anti_affinity: true
-    # Set the anti affinity type. Valid values: 
+  anti_affinity:
+    enabled: true
+    # Set the anti affinity topologyKey.
+    # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+    topologyKey:
+    # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-    type: preferredDuringSchedulingIgnoredDuringExecution 
+    type: preferredDuringSchedulingIgnoredDuringExecution
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -675,12 +695,15 @@ proxy:
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 10
-  affinity:
-    anti_affinity: true
-    # Set the anti affinity type. Valid values: 
+  anti_affinity:
+    enabled: true
+    # Set the anti affinity topologyKey.
+    # See some examples here https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels
+    topologyKey:
+    # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
-    type: requiredDuringSchedulingIgnoredDuringExecution 
+    type:
   annotations: {}
   tolerations: []
   gracePeriod: 30

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -137,6 +137,11 @@ images:
     repository: apachepulsar/pulsar-all
     tag: 2.6.1
     pullPolicy: IfNotPresent
+  # the image used for running `pulsar-cluster-initialize` job
+  pulsar_metadata:
+    repository:
+    tag:
+    pullPolicy:
   zookeeper:
     repository:
     tag:
@@ -550,11 +555,6 @@ autorecovery:
 ## metadata deployed
 pulsar_metadata:
   component: pulsar-init
-  image:
-    # the image used for running `pulsar-cluster-initialize` job
-    repository: apachepulsar/pulsar-all
-    tag: 2.6.1
-    pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:
   configurationStoreMetadataPrefix: ""


### PR DESCRIPTION
Fixes default anit-affinity type not being used

### Motivation

make life easier, fix broken stuff and add the ability to set `topologyKey`

### Modifications

- add a default image specifications for pulsar components
- a small refactor to anti-affinity rules, add `topologyKey`, and have defaults work
- use `publishNotReadyAddresses` correctly, expose it as a parameter, and remove deprecated alpha annotation

### Verifying this change

- [x] Make sure that the change passes the CI checks.
