### PR TITLE
Make forceSync by default as "yes"

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -345,7 +345,6 @@ zookeeper:
       -XX:+DoEscapeAnalysis
       -XX:+DisableExplicitGC
       -XX:+PerfDisableSharedMem
-      -Dzookeeper.forceSync=no
   ## Zookeeper service
   ## templates/zookeeper-service.yaml
   ##


### PR DESCRIPTION
### Motivation

* It's not recommended to run a production zookkeeper cluster with forceSync as "no".  This is also mentioned in the forceSync section in https://pulsar.apache.org/docs/en/next/reference-configuration/#zookeeper

### Modifications

* Removed ```-Dzookeeper.forceSync=no``` from ```values.yaml``` as default ```forceSync``` is ```yes```.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
