### PR TITLE
changed publishNotReadyAddresses to service spec from annotation

### DIFF
--- a/charts/pulsar/templates/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper-service.yaml
@@ -26,8 +26,10 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}
+{{- if .Values.bookkeeper.service.annotations }}
   annotations:
 {{ toYaml .Values.bookkeeper.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: bookie
@@ -38,4 +40,7 @@ spec:
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}
+  {{- if .Values.bookkeeper.service.spec }}
+    {{- toYaml .Values.bookkeeper.service.spec | trim | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -490,8 +490,8 @@ bookkeeper:
   ## templates/bookkeeper-service.yaml
   ##
   service:
-    annotations:
-      publishNotReadyAddresses: "true"
+    spec:
+      publishNotReadyAddresses: true
   ## Bookkeeper PodDisruptionBudget
   ## templates/bookkeeper-pdb.yaml
   ##


### PR DESCRIPTION
### Motivation

* ```publishNotReadyAddresses``` is a service spec and not a service annotation. This is mentioned in the K8s API docs at https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#servicespec-v1-core

### Modifications

* Modified ```publishNotReadyAddresses``` from annotation to service spec

### Verifying this change

- [x] Make sure that the change passes the CI checks.
