### PR TITLE
Allow use of existing secret for pulsar manager credentials

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.0
+version: 2.7.0-1
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
+++ b/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if or .Values.components.pulsar_manager .Values.extra.pulsar_manager }}
+{{- if and (or .Values.components.pulsar_manager .Values.extra.pulsar_manager) (not .Values.pulsar_manager.existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -72,12 +72,20 @@ spec:
             valueFrom:
               secretKeyRef:
                 key: PULSAR_MANAGER_ADMIN_USER
+                {{- if .Values.pulsar_manager.existingSecretName }}
+                name: "{{ .Values.pulsar_manager.existingSecretName }}"
+                {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                {{- end }}
           - name: PASSWORD
             valueFrom:
               secretKeyRef:
                 key: PULSAR_MANAGER_ADMIN_PASSWORD
+                {{- if .Values.pulsar_manager.existingSecretName }}
+                name: "{{ .Values.pulsar_manager.existingSecretName }}"
+                {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                {{- end }}
       volumes:
         - name: pulsar-manager-data
           emptyDir: {}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -963,6 +963,8 @@ pulsar_manager:
     hostname: ""
     path: "/"
 
+  ## If set use existing secret with specified name to set pulsar admin credentials.
+  existingSecretName:
   admin:
     user: pulsar
     password: pulsar


### PR DESCRIPTION
### Motivation

This allows store secrets out of the configuration file and manage them with external tools to keem them actualy secret.

### Modifications

Create the pulsar manager secret only conditionaly.

### Verifying this change

Tested on my own deployment.

- [ ] Make sure that the change passes the CI checks.
