### PR TITLE
Updating pods on configmap change

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -45,6 +45,9 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.autorecovery.ports.http }}"
+        {{- if .Values.autorecovery.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/autorecovery-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.autorecovery.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.bookkeeper.ports.http }}"
+        {{- if .Values.bookkeeper.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/bookkeeper-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.bookkeeper.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.broker.ports.http }}"
+        {{- if .Values.broker.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/broker-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.broker.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.grafana.component }}
       annotations:
+      {{- if .Values.grafana.restartPodsOnConfigMapChange }}
+      checksum/config: {{ include (print $.Template.BasePath "/grafana-configmap.yaml") . | sha256sum }}
+      {{- end }}
 {{- with .Values.grafana.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/prometheus-deployment.yaml
+++ b/charts/pulsar/templates/prometheus-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.prometheus.component }}
       annotations:
+      {{- if .Values.prometheus.restartPodsOnConfigMapChange }}
+      checksum/config: {{ include (print $.Template.BasePath "/prometheus-configmap.yaml") . | sha256sum }}
+      {{- end }}
 {{ toYaml .Values.prometheus.annotations | indent 8 }}
     spec:
     {{- if .Values.prometheus.nodeSelector }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.proxy.ports.http }}"
+        {{- if .Values.proxy.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.proxy.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.pulsar_manager.component }}
       annotations:
+      {{- if .Values.pulsar_manager.restartPodsOnConfigMapChange }}
+      checksum/config: {{ include (print $.Template.BasePath "/pulsar-manager-configmap.yaml") . | sha256sum }}
+      {{- end }}
 {{ toYaml .Values.pulsar_manager.annotations | indent 8 }}
     spec:
     {{- if .Values.pulsar_manager.nodeSelector }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -42,6 +42,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.toolset.component }}
       annotations:
+      {{- if .Values.toolset.restartPodsOnConfigMapChange }}
+      checksum/config: {{ include (print $.Template.BasePath "/toolset-configmap.yaml") . | sha256sum }}
+      {{- end }}
 {{ toYaml .Values.toolset.annotations | indent 8 }}
     spec:
     {{- if .Values.toolset.nodeSelector }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -43,6 +43,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.zookeeper.component }}
       annotations:
+      {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
+      checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
+      {{- end }}
 {{ toYaml .Values.zookeeper.annotations | indent 8 }}
     spec:
     {{- if .Values.zookeeper.nodeSelector }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -272,6 +272,8 @@ zookeeper:
     enabled: false
     interval: 10s
     scrapeTimeout: 10s
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   ports:
     http: 8000
     client: 2181
@@ -384,6 +386,8 @@ bookkeeper:
     enabled: false
     interval: 10s
     scrapeTimeout: 10s
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   ports:
     http: 8000
     bookie: 3181
@@ -506,6 +510,8 @@ autorecovery:
   # so the metrics are correctly rendered in grafana dashboard
   component: recovery
   replicaCount: 1
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   ports:
     http: 8000
   # nodeSelector:
@@ -567,6 +573,8 @@ broker:
     enabled: false
     interval: 10s
     scrapeTimeout: 10s
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   ports:
     http: 8080
     https: 8443
@@ -663,6 +671,8 @@ proxy:
     enabled: false
     interval: 10s
     scrapeTimeout: 10s
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   probe:
@@ -797,6 +807,8 @@ toolset:
   component: toolset
   useProxy: true
   replicaCount: 1
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   annotations: {}
@@ -830,6 +842,8 @@ prometheus:
   rbac:
     enabled: true
   replicaCount: 1
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   annotations: {}
@@ -870,6 +884,8 @@ prometheus:
 grafana:
   component: grafana
   replicaCount: 1
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   annotations: {}
@@ -921,6 +937,8 @@ grafana:
 pulsar_manager:
   component: pulsar-manager
   replicaCount: 1
+  # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
+  restartPodsOnConfigMapChange: false
   # nodeSelector:
   # cloud.google.com/gke-nodepool: default-pool
   annotations: {}


### PR DESCRIPTION
Fixes #71 

### Motivation

Pods are not restarting when config maps are changed after changing values.yaml file, so they need to be restarted manually in order to pick up new values from config map. 

### Modifications

As I mentioned `restartPodsOnConfigMapChange` flag for each component is added in values.yaml file whether to restart pods on configmap change or not, default is `false`.
In statefulset templates for each component is added part which is adding annotation that contains hash of corresponding configmap if `restartPodsOnConfigMapChange` is `true`, which will cause pods to restart if corresponding configmap has been changed (https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
