### PR TITLE
Allow appending dnsNames to self-signed certs

### DIFF
--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -47,6 +47,7 @@ spec:
   dnsNames:
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+{{ toYaml .Values.tls.proxy.dnsNames | indent 4 }}
   # Issuer references are always required.
   issuerRef:
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}-ca-issuer"
@@ -84,6 +85,7 @@ spec:
     - client auth
   # At least one of a DNS Name, USI SAN, or IP address is required.
   dnsNames:
+{{ toYaml .Values.tls.broker.dnsNames | indent 4 }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   # Issuer references are always required.
@@ -122,6 +124,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{ toYaml .Values.tls.bookkeeper.dnsNames | indent 4 }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   # Issuer references are always required.
@@ -160,6 +163,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{ toYaml .Values.tls.autorecovery.dnsNames | indent 4 }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   # Issuer references are always required.
@@ -195,6 +199,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{ toYaml .Values.tls.toolset.dnsNames | indent 4 }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   # Issuer references are always required.
@@ -230,6 +235,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{ toYaml .Values.tls.zookeeper.dnsNames | indent 4 }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   # Issuer references are always required.


### PR DESCRIPTION
Fixes inability to validate self-signed certs from external clients

### Motivation

Currently self-signed certificates can only be used inside of the same cluster as they are labeled with internal dns names without the possibility of appending additional values. Some use-cases require the connection of external clients. This PR aims to allow users add additional dnsNames (IP or domain) to the self-signed certificates.

### Modifications

* Adds the ability to add `dnsNames` to self-signed certificates to any component like so:

```yaml
tls:
  enabled: true
  proxy:
    enabled: true
    dnsNames:
      - test.example.com

```

### Verifying this change

- [x] Make sure that the change passes the CI checks.
