### PR TITLE
Fix "unknown apiVersion: kind.sigs.k8s.io/v1alpha3"

### DIFF
--- a/.ci/ct.sh
+++ b/.ci/ct.sh
@@ -23,7 +23,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_IMAGE=quay.io/helmpack/chart-testing:v2.4.0
+DEFAULT_IMAGE=quay.io/helmpack/chart-testing:v3.0.0
 
 show_help() {
 cat << EOF
@@ -65,12 +65,9 @@ main() {
     # charts changed.
     echo "::set-output name=changed::true"
 
-    if [[ "$command" == "lint" ]] || [[ "$command" == "list-changed" ]]; then
-        helm_init
     # All other ct commands require a cluster to be created in a previous step.
-    else
+    if [[ "$command" != "lint" ]] && [[ "$command" != "list-changed" ]]; then
         configure_kube
-        install_tiller
     fi
 
     run_ct
@@ -149,21 +146,6 @@ run_ct_container() {
 configure_kube() {
     docker_exec sh -c 'mkdir -p /root/.kube'
     docker cp "$kubeconfig" ct:/root/.kube/config
-}
-
-install_tiller() {
-    echo 'Installing Tiller...'
-    docker_exec sh -c 'kubectl create serviceaccount tiller --namespace kube-system --save-config --dry-run \
-        --output=yaml | kubectl apply -f -'
-    docker_exec sh -c 'kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin \
-        --serviceaccount=kube-system:tiller --save-config --dry-run --output=yaml | kubectl apply -f -'
-    docker_exec helm init --service-account tiller --upgrade --wait
-    echo
-}
-
-helm_init() {
-    docker_exec helm init --client-only
-    echo
 }
 
 run_ct() {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - '.ci/ct.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Precommit - Helm Chart Lint
+on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'charts/pulsar/**'
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check if this pull request only changes documentation
+        id:   docs
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: site2 .asf.yaml ct.yaml
+
+      - name: Lint chart
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: lint

--- a/.github/workflows/pulsar.yml
+++ b/.github/workflows/pulsar.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_bk_tls.yml
+++ b/.github/workflows/pulsar_bk_tls.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_broker_tls.yml
+++ b/.github/workflows/pulsar_broker_tls.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_function.yml
+++ b/.github/workflows/pulsar_function.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_image.yml
+++ b/.github/workflows/pulsar_image.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_jwt_asymmetric.yml
+++ b/.github/workflows/pulsar_jwt_asymmetric.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_jwt_symmetric.yml
+++ b/.github/workflows/pulsar_jwt_symmetric.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_tls.yml
+++ b/.github/workflows/pulsar_tls.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_zk_tls.yml
+++ b/.github/workflows/pulsar_zk_tls.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pulsar_zkbk_tls.yml
+++ b/.github/workflows/pulsar_zkbk_tls.yml
@@ -24,6 +24,7 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - 'hack/kind-cluster-build.sh'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -117,7 +117,7 @@ configFile=${workDir}/kind-config.yaml
 
 cat <<EOF > ${configFile}
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraPortMappings:


### PR DESCRIPTION
*Motivation*

The api version `kind.sigs.k8s.io/v1alpha3` is not available anymore for kind clusters.
So all the CI actions are broken now. This PR fix the issue.

Additionally it adds a helm chart lint job to lint the chart changes.

