### PR TITLE
Upgrade chart-testing-action to 2.0.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,6 @@ jobs:
 
       - name: Lint chart
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v2.0.0
         with:
           command: lint


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

The lint ci error as follows:

```
Linting chart 'pulsar => (version: "2.6.2-1", path: "charts/pulsar")'
Checking chart 'pulsar => (version: "2.6.2-1", path: "charts/pulsar")' for a version bump...
Old chart version: 2.6.1-2
New chart version: 2.6.2-1
Chart version ok.
Validating /workdir/charts/pulsar/Chart.yaml...
Validation success! 👍
Validating maintainers...
Error: Error linting charts: Error processing charts
------------------------------------------------------------------------------------------------------------------------
 ✖︎ pulsar => (version: "2.6.2-1", path: "charts/pulsar") > Error validating maintainer 'The Apache Pulsar Team': 404 Not Found
------------------------------------------------------------------------------------------------------------------------
Error linting charts: Error processing charts
```

### Modifications

Upgrade `chart-testing-action` to 2.0.0

### Verifying this change

- [x] Make sure that the change passes the CI checks.
