### PR TITLE
Add basic PSP and RBAC for core components

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.0
+version: 2.7.0-1
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/autorecovery-rbac.yaml
+++ b/charts/pulsar/templates/autorecovery-rbac.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/charts/pulsar/templates/autorecovery-rbac.yaml
+++ b/charts/pulsar/templates/autorecovery-rbac.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.rbac.enabled .Values.rbac.psp }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ .Values.namespace }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+subjects:
+- kind: ServiceAccount
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ .Values.namespace }}
+---
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ .Values.namespace }}
+spec:
+  readOnlyRootFilesystem: false
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsUser:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+{{- end }}

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -101,6 +101,9 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.autorecovery.gracePeriod }}
+    {{- if and .Values.rbac.enabled  .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+    {{- end}}
       initContainers:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before deploying the bookies
@@ -124,6 +127,10 @@ spec:
         resources:
 {{ toYaml .Values.autorecovery.resources | indent 10 }}
       {{- end }}
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end}}
         command: ["sh", "-c"]
         args:
         - >

--- a/charts/pulsar/templates/bookkeeper-rbac.yaml
+++ b/charts/pulsar/templates/bookkeeper-rbac.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.rbac.enabled .Values.rbac.psp }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+  namespace: {{ .Values.namespace }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+subjects:
+- kind: ServiceAccount
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+  namespace: {{ .Values.namespace }}
+---
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+  namespace: {{ .Values.namespace }}
+spec:
+  readOnlyRootFilesystem: false
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsUser:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  {{- end}}

--- a/charts/pulsar/templates/bookkeeper-rbac.yaml
+++ b/charts/pulsar/templates/bookkeeper-rbac.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -98,6 +98,9 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
+    {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+    {{- end}}
       initContainers:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before deploying the bookies
@@ -112,6 +115,10 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end}}
         volumeMounts:
         {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
       containers:
@@ -155,6 +162,10 @@ spec:
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           exec bin/pulsar bookie;
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end}}
         ports:
         - name: bookie
           containerPort: {{ .Values.bookkeeper.ports.bookie }}

--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -20,7 +20,11 @@
 {{- if .Values.components.broker }}
 ## TODO create our own cluster role with less privledges than admin
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
+kind: RoleBinding
+{{- else}}
 kind: ClusterRoleBinding
+{{- end}}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrolebinding"
   labels:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -68,6 +68,17 @@ volumes:
   # the local provisioner should be installed prior to enable local persistent volume
   local_storage: false
 
+## RBAC
+##
+## Configure settings related to RBAC such as limiting broker access to single
+## namespece or enabling PSP
+
+rbac:
+  enabled: false
+  psp: false
+  limit_to_namespace: false
+
+
 ## AntiAffinity
 ##
 ## Flag to enable and disable `AntiAffinity` for all components.


### PR DESCRIPTION
Add PSP and add/modify RBAC. I'm open for all discussion.

### Motivation

On clusters which use PSP and restrictive default policy pulsar cannot be installed, because it uses root user and requires writable container root directory. Additionally default RBAC for broker are too permissive (usage of ClusterRoleBinding) in my opinion.

### Modifications

Add PSP and RBAC for bookkeeper and autorecovery to add
exception to allow startup even in secure environment
where containers cannot access RW on root by default.

Add option for limiting broker ClusterRoleBinding
to single namespace by replacing to RoleBinding

### Verifying this change

- [x] Make sure that the change passes the CI checks.
