### PR TITLE
Support single PV for journal and ledgers

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -178,10 +178,15 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         volumeMounts:
+        {{- if .Values.bookkeeper.volumes.useSingleCommonVolume }}
+          - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
+            mountPath: /pulsar/data/bookkeeper
+        {{- else }}
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
           mountPath: /pulsar/data/bookkeeper/journal
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
           mountPath: /pulsar/data/bookkeeper/ledgers
+        {{- end}}
         {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) }}
@@ -193,6 +198,22 @@ spec:
       {{- include "pulsar.bookkeeper.certs.volumes" . | nindent 6 }}
 {{- if and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence}}
   volumeClaimTemplates:
+  {{- if .Values.bookkeeper.volumes.useSingleCommonVolume }}
+    - metadata:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.bookkeeper.volumes.common.size }}
+        {{- if .Values.bookkeeper.volumes.common.storageClassName }}
+        storageClassName: "{{ .Values.bookkeeper.volumes.common.storageClassName }}"
+        {{- else if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.common.local_storage)) .Values.bookkeeper.volumes.common.storageClass }}
+        storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
+        {{- else if and .Values.volumes.local_storage .Values.bookkeeper.volumes.common.local_storage }}
+        storageClassName: "local-storage"
+        {{- end }}
+  {{- else }}
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
     spec:
@@ -221,5 +242,6 @@ spec:
     {{- else if and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage }}
       storageClassName: "local-storage"
     {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-storageclass.yaml
+++ b/charts/pulsar/templates/bookkeeper-storageclass.yaml
@@ -19,7 +19,26 @@
 
 {{- if .Values.components.bookkeeper }}
 {{- if and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence }}
-{{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage)) .Values.bookkeeper.volumes.journal.storageClass }}
+{{- if not .Values.volumes.local_storage }}
+
+{{- if .Values.bookkeeper.volumes.useSingleCommonVolume}}
+{{- if and (not .Values.bookkeeper.volumes.common.local_storage) .Values.bookkeeper.volumes.common.storageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.bookkeeper.component }}
+provisioner: {{ .Values.bookkeeper.volumes.common.storageClass.provisioner }}
+parameters:
+  type: {{ .Values.bookkeeper.volumes.common.storageClass.type }}
+  fsType: {{ .Values.bookkeeper.volumes.common.storageClass.fsType }}
+{{- end }}
+{{- else }}
+
+{{- if and (not .Values.bookkeeper.volumes.journal.local_storage) .Values.bookkeeper.volumes.journal.storageClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -34,8 +53,7 @@ parameters:
   fsType: {{ .Values.bookkeeper.volumes.journal.storageClass.fsType }}
 {{- end }}
 ---
-
-{{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage)) .Values.bookkeeper.volumes.ledgers.storageClass }}
+{{- if and (not .Values.bookkeeper.volumes.ledgers.local_storage) .Values.bookkeeper.volumes.ledgers.storageClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -49,6 +67,8 @@ parameters:
   type: {{ .Values.bookkeeper.volumes.ledgers.storageClass.type }}
   fsType: {{ .Values.bookkeeper.volumes.ledgers.storageClass.fsType }}
 {{- end }}
+{{- end }}
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -456,17 +456,20 @@ bookkeeper:
       name: ledgers
       size: 50Gi
       local_storage: true
-      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
-      ##
-      # storageClassName: existent-storage-class
-      #
-      ## Instead if you want to create a new storage class define it below
-      ## If left undefined no storage class will be defined along with PVC
-      ##
+      # storageClassName:
       # storageClass:
-        # type: pd-ssd
-        # fsType: xfs
-        # provisioner: kubernetes.io/gce-pd
+        # ...
+
+    ## use a single common volume for both journal and ledgers
+    useSingleCommonVolume: false
+    common:
+      name: common
+      size: 60Gi
+      local_storage: true
+      # storageClassName:
+      # storageClass: ## this is common too
+        # ...
+
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##


### PR DESCRIPTION
### Motivation

In some case, my k8s node only have 1 large capacity ssd, for deploying 1 bookie, I need:

- Partition the ssd into 2 disks, and make 2 pv over it.
- Just make 1 pv over it, but journal & ledgers under same mount path (this PR did)

Both can't isolate IO for journal & ledgers, so I prefer the second one for reusability.


### Modifications

values.yaml
  - add `useSingleCommonVolume` option, default false

bookkeeper-statefulset.yaml
   - mount the only PV to path `/pulsar/data/bookkeeper`
   - use configured common storageClassName

bookkeeper-storageclass.yaml
  - use configured provisioner for the common storageClass 

### Others
This may not be an issue for everyone, if it's not necessary to merge, I'll just use it locally

### Verifying this change

- [x] Make sure that the change passes the CI checks.
