### PR TITLE
fix broker configmap forbidden

### DIFF
--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -48,7 +48,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - configmap
+  - configmaps
   verbs: ["get", "list", "watch"]
 - apiGroups: ["", "extensions", "apps"]
   resources:


### PR DESCRIPTION
Fixes #94

### Motivation

fix `io.kubernetes.client.openapi.ApiException: Forbidden`

### Modifications

fix typo

### Verifying this change

- [x] Make sure that the change passes the CI checks.
