### PR TITLE
Automatically pass bookieId to the bookie as metadata.name

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -178,10 +178,12 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         env:
+        {{- if .Values.bookkeeper.usePodNameAsBookiedId }}
         - name: PULSAR_PREFIX_bookieId
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- end}}
         volumeMounts:
         {{- if .Values.bookkeeper.volumes.useSingleCommonVolume }}
           - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -177,6 +177,11 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+        env:
+        - name: PULSAR_PREFIX_bookieId
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         volumeMounts:
         {{- if .Values.bookkeeper.volumes.useSingleCommonVolume }}
           - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -178,7 +178,7 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         env:
-        {{- if .Values.bookkeeper.usePodNameAsBookiedId }}
+        {{- if .Values.bookkeeper.usePodNameAsBookieId }}
         - name: PULSAR_PREFIX_bookieId
           valueFrom:
             fieldRef:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -394,7 +394,7 @@ bookkeeper:
     type: RollingUpdate
   podManagementPolicy: Parallel
   # Use Pod Name as bookieId insteand of using hostname:port
-  usePodNameAsBookiedId: false
+  usePodNameAsBookieId: false
   # If using Prometheus-Operator enable this PodMonitor to discover bookie scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -393,6 +393,8 @@ bookkeeper:
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
+  # Use Pod Name as bookieId insteand of using hostname:port
+  usePodNameAsBookiedId: false
   # If using Prometheus-Operator enable this PodMonitor to discover bookie scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:


### PR DESCRIPTION
### Motivation

In Pulsar 2.7.x you can configured a bookieId that is the unique identifier of the Bookie and it does not depend on the network address of the bookie.
In Kubernetes we can set the bookieId as the name of the Pod, this way we are going to decouple the BookieId from the hostname and also from the main Bookie binary protocol endpoint (hostname:port)

see
http://bookkeeper.apache.org/bps/BP-41-bookieid/

### Modifications
Add new configuration parameter `bookkeeper.usePodNameAsBookieId`
in that case we pass the PULSAR_PREFIX_bookieId env variable, filled with metadata.name.

It is not possible to upgrade an existing Bookie to this new mode, in order to switch to BookieId manually you have to set  bookieId equals to the current bookieId you are seeing for the bookie, but this cannot be done within the Helm Chart.