### PR TITLE
The name of the resource for accessing ConfigMap object is 'configmaps'

### DIFF
--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -48,7 +48,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - configmap
+  - configmaps
   verbs: ["get", "list", "watch"]
 - apiGroups: ["", "extensions", "apps"]
   resources:


### PR DESCRIPTION
### Motivation

Exception while trying to get configmap as following error log:
ERROR org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory - Error while trying to fetch configmap pulsar-functions-worker-config at namespace pulsar
io.kubernetes.client.openapi.ApiException: Forbidden
	at io.kubernetes.client.openapi.ApiClient.handleResponse(ApiClient.java:971) ~[io.kubernetes-client-java-api-9.0.2.jar:?]
	at io.kubernetes.client.openapi.ApiClient.execute(ApiClient.java:883) ~[io.kubernetes-client-java-api-9.0.2.jar:?]
	at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedConfigMapWithHttpInfo(CoreV1Api.java:44821) ~[io.kubernetes-client-java-api-9.0.2.jar:?]
	at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedConfigMap(CoreV1Api.java:44791) ~[io.kubernetes-client-java-api-9.0.2.jar:?]
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory.fetchConfigMap(KubernetesRuntimeFactory.java:369) [org.apache.pulsar-pulsar-functions-runtime-2.7.0.jar:2.7.0]
	at org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory$1.run(KubernetesRuntimeFactory.java:358) [org.apache.pulsar-pulsar-functions-runtime-2.7.0.jar:2.7.0]
	at java.util.TimerThread.mainLoop(Timer.java:555) [?:1.8.0_275]
	at java.util.TimerThread.run(Timer.java:505) [?:1.8.0_275]

### Modifications

Fixed resource name for ConfigMap object
