### PR TITLE
Fix namespace handling and missing dnsNames

### DIFF
--- a/charts/pulsar/templates/autorecovery-rbac.yaml
+++ b/charts/pulsar/templates/autorecovery-rbac.yaml
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 rules:
   - apiGroups:
       - policy
@@ -38,14 +38,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,14 +53,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/bookkeeper-rbac.yaml
+++ b/charts/pulsar/templates/bookkeeper-rbac.yaml
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 rules:
   - apiGroups:
       - policy
@@ -38,14 +38,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,14 +53,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -47,7 +47,9 @@ spec:
   dnsNames:
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+{{- if .Values.tls.proxy.dnsNames }}
 {{ toYaml .Values.tls.proxy.dnsNames | indent 4 }}
+{{- end }}
   # Issuer references are always required.
   issuerRef:
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}-ca-issuer"
@@ -85,7 +87,9 @@ spec:
     - client auth
   # At least one of a DNS Name, USI SAN, or IP address is required.
   dnsNames:
+{{- if .Values.tls.broker.dnsNames }}
 {{ toYaml .Values.tls.broker.dnsNames | indent 4 }}
+{{- end}}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   # Issuer references are always required.
@@ -124,7 +128,9 @@ spec:
     - server auth
     - client auth
   dnsNames:
-{{ toYaml .Values.tls.bookkeeper.dnsNames | indent 4 }}
+{{- if .Values.tls.bookie.dnsNames }}
+{{ toYaml .Values.tls.bookie.dnsNames | indent 4 }}
+{{- end }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   # Issuer references are always required.
@@ -163,7 +169,9 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{- if .Values.tls.autorecovery.dnsNames }}
 {{ toYaml .Values.tls.autorecovery.dnsNames | indent 4 }}
+{{- end }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   # Issuer references are always required.
@@ -199,7 +207,9 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{- if .Values.tls.toolset.dnsNames }}
 {{ toYaml .Values.tls.toolset.dnsNames | indent 4 }}
+{{- end }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   # Issuer references are always required.
@@ -235,7 +245,9 @@ spec:
     - server auth
     - client auth
   dnsNames:
+{{- if .Values.tls.zookeeper.dnsNames }}
 {{ toYaml .Values.tls.zookeeper.dnsNames | indent 4 }}
+{{- end }}
     -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   # Issuer references are always required.


### PR DESCRIPTION
Fixes for wrong namespace handling in some RBAC and missing dnsNames for TLS

### Motivation

Fixes old unused handling of namespace name in RBAC for autorecovery and bookkeeper.
Fixes Helm exception of missing key when not defining TLS dnsNames

### Modifications

Use namespace template in RBAC definitions for bookkeeper and autorecovery. Add if around every `toYaml .Values.tls.bookie.dnsNames` clause in TLS certs definitions.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
