### PR TITLE
Fix for missing PSP for bookie initialize and other

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -29,6 +29,9 @@ metadata:
 spec:
   template:
     spec:
+    {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+    {{- end }}
       initContainers:
       - name: wait-zookeeper-ready
         image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
@@ -66,6 +69,10 @@ spec:
                 {{- end }}
                 bin/bookkeeper shell initnewcluster;
             fi
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -120,6 +120,10 @@ spec:
             {{- end }}
               echo "pulsar cluster {{ template "pulsar.cluster.name" . }} isn't initialized yet ... check in 3 seconds ..." && sleep 3;
             done;
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
         volumeMounts:
         {{- include "pulsar.broker.certs.volumeMounts" . | nindent 8 }}
       # This init container will wait for bookkeeper to be ready before
@@ -147,6 +151,10 @@ spec:
         envFrom:
           - configMapRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
         volumeMounts:
         {{- include "pulsar.broker.certs.volumeMounts" . | nindent 10 }}
       containers:
@@ -228,6 +236,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- include "pulsar.broker.certs.volumeMounts" . | nindent 10 }}
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
       volumes:
       {{- if .Values.auth.authentication.enabled }}
       {{- if eq .Values.auth.authentication.provider "jwt" }}

--- a/charts/pulsar/templates/proxy-rbac.yaml
+++ b/charts/pulsar/templates/proxy-rbac.yaml
@@ -17,87 +17,49 @@
 # under the License.
 #
 
-{{- if or .Values.components.functions .Values.extra.functionsAsPods }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-rules:
-- apiGroups: [""]
-  resources:
-  - services
-  - configmaps
-  - pods
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-subjects:
-- kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
-{{- end }}
-
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
----
-
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 rules:
   - apiGroups:
       - policy
     resourceNames:
-      - "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+      - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
     resources:
       - podsecuritypolicies
     verbs:
       - use
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   readOnlyRootFilesystem: false
@@ -124,4 +86,4 @@ spec:
   - secret
   - downwardAPI
   - persistentVolumeClaim
-{{- end}}
+  {{- end}}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -101,6 +101,9 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}
+    {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+    {{- end}}
       initContainers:
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
@@ -189,6 +192,10 @@ spec:
         - name: pulsarssl
           containerPort: {{ .Values.proxy.ports.pulsarssl }}
         {{- end }}
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/toolset-rbac.yaml
+++ b/charts/pulsar/templates/toolset-rbac.yaml
@@ -17,87 +17,49 @@
 # under the License.
 #
 
-{{- if or .Values.components.functions .Values.extra.functionsAsPods }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-rules:
-- apiGroups: [""]
-  resources:
-  - services
-  - configmaps
-  - pods
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-subjects:
-- kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
-{{- end }}
-
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
----
-
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 rules:
   - apiGroups:
       - policy
     resourceNames:
-      - "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+      - "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
     resources:
       - podsecuritypolicies
     verbs:
       - use
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   readOnlyRootFilesystem: false
@@ -124,4 +86,4 @@ spec:
   - secret
   - downwardAPI
   - persistentVolumeClaim
-{{- end}}
+  {{- end}}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -56,6 +56,9 @@ spec:
 {{ toYaml .Values.toolset.tolerations | indent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
+    {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+    {{- end}}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
         image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
@@ -71,6 +74,10 @@ spec:
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 10 }}
           sleep 10000000000
+      {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+      {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"

--- a/charts/pulsar/templates/zookeeper-rbac.yaml
+++ b/charts/pulsar/templates/zookeeper-rbac.yaml
@@ -17,87 +17,49 @@
 # under the License.
 #
 
-{{- if or .Values.components.functions .Values.extra.functionsAsPods }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-rules:
-- apiGroups: [""]
-  resources:
-  - services
-  - configmaps
-  - pods
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-subjects:
-- kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
-{{- end }}
-
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
----
-
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 rules:
   - apiGroups:
       - policy
     resourceNames:
-      - "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+      - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
     resources:
       - podsecuritypolicies
     verbs:
       - use
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   readOnlyRootFilesystem: false
@@ -124,4 +86,4 @@ spec:
   - secret
   - downwardAPI
   - persistentVolumeClaim
-{{- end}}
+  {{- end}}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -98,6 +98,9 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
+    {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+    {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ .Values.images.zookeeper.repository }}:{{ .Values.images.zookeeper.tag }}"
@@ -136,6 +139,10 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         {{- if .Values.zookeeper.probe.readiness.enabled }}
+        {{- if and .Values.rbac.enabled .Values.rbac.psp }}
+        securityContext:
+          readOnlyRootFilesystem: false
+        {{- end}}
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
### Motivation

When using standard bookkeeper installation on PSP cluster initialization fails because has to be started as root

### Modifications

Add same ServiceAccount and SecurityContext for bookkeeper-cluster-initialize as in bookkeeper specyfication.

UPDATE: Seems that when using in cluster TLS encryption other components also require RW access to root FS, I added PSP for proxy, zookeepe, broker and toolset

### Verifying this change

- [x] Make sure that the change passes the CI checks.
