### PR TITLE
makes cert-manager apiVersion configurable

### DIFF
--- a/charts/pulsar/templates/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls-cert-internal-issuer.yaml
@@ -19,7 +19,7 @@
 
 {{- if .Values.certs.internal_issuer.enabled }}
 {{- if eq .Values.certs.internal_issuer.type "selfsigning" }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}"
@@ -28,7 +28,7 @@ spec:
   selfSigned: {}
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-ca"
@@ -50,7 +50,7 @@ spec:
     group: cert-manager.io
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}-ca-issuer"

--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -21,7 +21,7 @@
 {{- if .Values.certs.internal_issuer.enabled }}
 
 {{- if .Values.tls.proxy.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.proxy.cert_name }}"
@@ -63,7 +63,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.broker.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled) }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.broker.cert_name }}"
@@ -105,7 +105,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.bookie.cert_name }}"
@@ -146,7 +146,7 @@ spec:
 {{- end }}
 
 {{- if .Values.tls.zookeeper.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.autorecovery.cert_name }}"
@@ -184,7 +184,7 @@ spec:
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.toolset.cert_name }}"
@@ -222,7 +222,7 @@ spec:
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.zookeeper.cert_name }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -256,6 +256,7 @@ auth:
 ## for components within a Pulsar cluster
 certs:
   internal_issuer:
+    apiVersion: cert-manager.io/v1alpha2
     enabled: false
     component: internal-cert-issuer
     type: selfsigning


### PR DESCRIPTION

This commit let's users override the apiVersion referenced in this
chart so that the chart can be used with newer cert-manager releases.
(script/cert-manager/install-cert-manager.sh installs 0.13.0 when
current version is 1.2.0...)

Fixes #68

### Motivation

cert-manager apiVersion changed after cert-manager 1.0.0 was released, which prevents the chart from provisionning certificates with newer cert-manager installation because of an incompatible apiVersion.

I have a cluster with cert-manager >1.0.0 installed, making `apiVersion` overridable makes it easy for me to install pulsar on that cluster

### Modifications

I introduced the value `certs.internal_issuer.apiVersion`, which by default uses the apiVersion that was previously hardcoded (`cert-manager.io/v1alpha2`) 
I replaced all occurrences of that apiVersion by a reference to the value so that users can override it to `cert-manager.io/v1` if they have a newer version of cert-manager installed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
