### PR TITLE
Add multi volume support in bookkeeper.

### DIFF
--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -35,9 +35,26 @@ data:
   {{- end }}
   # Do not retain journal files as it increase the disk utilization
   journalMaxBackups: "0"
+  {{- if .Values.bookkeeper.volumes.journal.useMultiVolumes }}
+  {{- $journalDirs := list -}}
+  {{ range .Values.bookkeeper.volumes.journal.multiVolumes }}
+  {{- $journalDirs = append $journalDirs .mountPath -}}
+  {{- end }}
+  journalDirectories: {{ $journalDirs | join "," | quote }}
+  PULSAR_PREFIX_journalDirectories: {{ $journalDirs | join "," | quote }}
+  {{- else }}
   journalDirectories: "/pulsar/data/bookkeeper/journal"
   PULSAR_PREFIX_journalDirectories: "/pulsar/data/bookkeeper/journal"
+  {{- end }}
+  {{- if .Values.bookkeeper.volumes.ledgers.useMultiVolumes }}
+  {{- $ledgerDirs := list -}}
+  {{ range .Values.bookkeeper.volumes.ledgers.multiVolumes }}
+  {{- $ledgerDirs = append $ledgerDirs .mountPath -}}
+  {{- end }}
+  ledgerDirectories: {{ $ledgerDirs | join "," | quote }}
+  {{- else }}
   ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
+  {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -182,11 +182,29 @@ spec:
           - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
             mountPath: /pulsar/data/bookkeeper
         {{- else }}
+        {{- if .Values.bookkeeper.volumes.journal.useMultiVolumes }}
+          {{- $fullname := include "pulsar.fullname" . -}}
+          {{- $bkComponent := .Values.bookkeeper.component -}}
+          {{ range .Values.bookkeeper.volumes.journal.multiVolumes }}
+        - name: "{{ $fullname }}-{{ $bkComponent }}-{{ .name }}"
+          mountPath: {{ .mountPath }}
+          {{- end }}
+        {{- else }}
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
           mountPath: /pulsar/data/bookkeeper/journal
+        {{- end}}
+        {{- if .Values.bookkeeper.volumes.ledgers.useMultiVolumes }}
+          {{- $fullname := include "pulsar.fullname" . -}}
+          {{- $bkComponent := .Values.bookkeeper.component -}}
+          {{ range .Values.bookkeeper.volumes.ledgers.multiVolumes }}
+        - name: "{{ $fullname }}-{{ $bkComponent }}-{{ .name }}"
+          mountPath: {{ .mountPath }}
+          {{- end }}
+        {{- else }}
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
           mountPath: /pulsar/data/bookkeeper/ledgers
-        {{- end}}
+        {{- end }}
+        {{- end }}
         {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) }}
@@ -214,6 +232,22 @@ spec:
         storageClassName: "local-storage"
         {{- end }}
   {{- else }}
+  {{- if .Values.bookkeeper.volumes.journal.useMultiVolumes }}
+  {{- $fullname := include "pulsar.fullname" . -}}
+  {{- $bkComponent := .Values.bookkeeper.component -}}
+  {{ range .Values.bookkeeper.volumes.journal.multiVolumes }}
+  - metadata:
+      name: "{{ $fullname }}-{{ $bkComponent }}-{{ .name }}"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .size }}
+    {{- if .storageClassName }}
+      storageClassName: "{{ .storageClassName }}"
+    {{- end }}
+  {{- end }}
+  {{- else }}
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
     spec:
@@ -228,6 +262,23 @@ spec:
     {{- else if and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage }}
       storageClassName: "local-storage"
     {{- end }}
+  {{- end }}
+  {{- if .Values.bookkeeper.volumes.ledgers.useMultiVolumes }}
+  {{- $fullname := include "pulsar.fullname" . -}}
+  {{- $bkComponent := .Values.bookkeeper.component -}}
+  {{ range .Values.bookkeeper.volumes.ledgers.multiVolumes }}
+  - metadata:
+      name: "{{ $fullname }}-{{ $bkComponent }}-{{ .name }}"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .size }}
+    {{- if .storageClassName }}
+      storageClassName: "{{ .storageClassName }}"
+    {{- end }}
+    {{- end }}
+  {{- else }}
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
     spec:
@@ -242,6 +293,7 @@ spec:
     {{- else if and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage }}
       storageClassName: "local-storage"
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -453,6 +453,17 @@ bookkeeper:
         # type: pd-ssd
         # fsType: xfs
         # provisioner: kubernetes.io/gce-pd
+      useMultiVolumes: false
+      # If using multiVolumes, remember to update the `journalDirectories` conf.
+      multiVolumes:
+        - name: journal0
+          size: 10Gi
+          # storageClassName: existent-storage-class
+          mountPath: /pulsar/data/bookkeeper/journal0
+        - name: journal1
+          size: 10Gi
+          # storageClassName: existent-storage-class
+          mountPath: /pulsar/data/bookkeeper/journal1
     ledgers:
       name: ledgers
       size: 50Gi
@@ -460,6 +471,17 @@ bookkeeper:
       # storageClassName:
       # storageClass:
         # ...
+      useMultiVolumes: false
+      # If using multiVolumes, remember to update the `ledgerDirectories` conf.
+      multiVolumes:
+        - name: ledgers0
+          size: 10Gi
+          # storageClassName: existent-storage-class
+          mountPath: /pulsar/data/bookkeeper/ledgers0
+        - name: ledgers1
+          size: 10Gi
+          # storageClassName: existent-storage-class
+          mountPath: /pulsar/data/bookkeeper/ledgers1
 
     ## use a single common volume for both journal and ledgers
     useSingleCommonVolume: false

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -454,7 +454,6 @@ bookkeeper:
         # fsType: xfs
         # provisioner: kubernetes.io/gce-pd
       useMultiVolumes: false
-      # If using multiVolumes, remember to update the `journalDirectories` conf.
       multiVolumes:
         - name: journal0
           size: 10Gi
@@ -472,7 +471,6 @@ bookkeeper:
       # storageClass:
         # ...
       useMultiVolumes: false
-      # If using multiVolumes, remember to update the `ledgerDirectories` conf.
       multiVolumes:
         - name: ledgers0
           size: 10Gi


### PR DESCRIPTION
Fixes #112 

### Motivation

*Add option for user to choose whether using multi volume in bookeeper, especially while using `local-storage`.*

### Modifications

Add `useMultiVolumes` option under `.Values.bookkeeper.volumes.journal` and `.Values.bookkeeper.volumes.ledgers`.
User can choose how many volumes could be used for bookkeeper jounal or ledgers.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
