### PR TITLE
Fix indentation issue on `checksum/config`

### DIFF
--- a/charts/pulsar/templates/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana-deployment.yaml
@@ -38,9 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.grafana.component }}
       annotations:
-      {{- if .Values.grafana.restartPodsOnConfigMapChange }}
-      checksum/config: {{ include (print $.Template.BasePath "/grafana-configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- if .Values.grafana.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/grafana-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{- with .Values.grafana.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/templates/prometheus-deployment.yaml
+++ b/charts/pulsar/templates/prometheus-deployment.yaml
@@ -38,9 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.prometheus.component }}
       annotations:
-      {{- if .Values.prometheus.restartPodsOnConfigMapChange }}
-      checksum/config: {{ include (print $.Template.BasePath "/prometheus-configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- if .Values.prometheus.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/prometheus-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{ toYaml .Values.prometheus.annotations | indent 8 }}
     spec:
     {{- if .Values.prometheus.nodeSelector }}

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -38,9 +38,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.pulsar_manager.component }}
       annotations:
-      {{- if .Values.pulsar_manager.restartPodsOnConfigMapChange }}
-      checksum/config: {{ include (print $.Template.BasePath "/pulsar-manager-configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- if .Values.pulsar_manager.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/pulsar-manager-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{ toYaml .Values.pulsar_manager.annotations | indent 8 }}
     spec:
     {{- if .Values.pulsar_manager.nodeSelector }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -42,9 +42,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.toolset.component }}
       annotations:
-      {{- if .Values.toolset.restartPodsOnConfigMapChange }}
-      checksum/config: {{ include (print $.Template.BasePath "/toolset-configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- if .Values.toolset.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/toolset-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{ toYaml .Values.toolset.annotations | indent 8 }}
     spec:
     {{- if .Values.toolset.nodeSelector }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -43,9 +43,9 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.zookeeper.component }}
       annotations:
-      {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
-      checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
-      {{- end }}
+        {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
+        {{- end }}
 {{ toYaml .Values.zookeeper.annotations | indent 8 }}
     spec:
     {{- if .Values.zookeeper.nodeSelector }}


### PR DESCRIPTION
Fixes #116

### Motivation

Theres indentation issues for the `checksum/config` annotation in these templates, which would either fail linting or not apply at all in some situations.

### Modifications

I've added indentation at the specified places such that this isn't an issue anymore.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
