### PR TITLE
Consistently use the 'pulsar.matchLabels' template for matching

### DIFF
--- a/charts/pulsar/templates/autorecovery-podmonitor.yaml
+++ b/charts/pulsar/templates/autorecovery-podmonitor.yaml
@@ -50,5 +50,6 @@ spec:
           targetLabel: kubernetes_pod_name
   selector:
     matchLabels:
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: {{ .Values.autorecovery.component }}
 {{- end }}

--- a/charts/pulsar/templates/autorecovery-service.yaml
+++ b/charts/pulsar/templates/autorecovery-service.yaml
@@ -32,8 +32,7 @@ spec:
     port: {{ .Values.autorecovery.ports.http }}
   clusterIP: None
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}
 {{- end }}
 

--- a/charts/pulsar/templates/bookkeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/bookkeeper-podmonitor.yaml
@@ -50,5 +50,6 @@ spec:
           targetLabel: kubernetes_pod_name
   selector:
     matchLabels:
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: bookie
 {{- end }}

--- a/charts/pulsar/templates/broker-podmonitor.yaml
+++ b/charts/pulsar/templates/broker-podmonitor.yaml
@@ -50,5 +50,6 @@ spec:
           targetLabel: kubernetes_pod_name
   selector:
     matchLabels:
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: broker
 {{- end }}

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -45,7 +45,6 @@ spec:
   {{- end }}
   clusterIP: None
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}
 {{- end }}

--- a/charts/pulsar/templates/dashboard-deployment.yaml
+++ b/charts/pulsar/templates/dashboard-deployment.yaml
@@ -30,8 +30,7 @@ spec:
   replicas: {{ .Values.dashboard.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "pulsar.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: {{ .Values.dashboard.component }}
   template:
     metadata:

--- a/charts/pulsar/templates/dashboard-service.yaml
+++ b/charts/pulsar/templates/dashboard-service.yaml
@@ -33,7 +33,6 @@ spec:
 {{ toYaml .Values.dashboard.service.ports | indent 2 }}
   clusterIP: None
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.dashboard.component }}
 {{- end }}

--- a/charts/pulsar/templates/prometheus-service.yaml
+++ b/charts/pulsar/templates/prometheus-service.yaml
@@ -34,7 +34,6 @@ spec:
     - name: server
       port: {{ .Values.prometheus.port }}
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.prometheus.component }}
 {{- end }}

--- a/charts/pulsar/templates/proxy-podmonitor.yaml
+++ b/charts/pulsar/templates/proxy-podmonitor.yaml
@@ -50,5 +50,6 @@ spec:
           targetLabel: kubernetes_pod_name
   selector:
     matchLabels:
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: proxy
 {{- end }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -50,7 +50,6 @@ spec:
       protocol: TCP
     {{- end }}
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -36,8 +36,7 @@ spec:
       targetPort: {{ .Values.pulsar_manager.service.targetPort }}
       protocol: TCP
   selector:
-    app: {{ template "pulsar.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
 {{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:

--- a/charts/pulsar/templates/zookeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/zookeeper-podmonitor.yaml
@@ -50,5 +50,6 @@ spec:
           targetLabel: kubernetes_pod_name
   selector:
     matchLabels:
+      {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: zookeeper
 {{- end }}


### PR DESCRIPTION
This also limits the scope of the PodMonitors to the resources of only this install, instead of all installs that share `component:` label values.

Fixes some issues with overly broad PodMonitor selectors, and put all selectors (except affinity selectors) in one line w.r.t. how they are generated.

### Motivation

This chart has several templates for generating standardized labels, which can be overridden by the user for using their own label scheme. Due to inconsistently applied labelSelector templates, this is only partially viable. By consistently applying the `pulsar.matchLabels` template, this makes the chart more extendable, and by extension, more useable. 

Additionally, PodMonitor resources specified an overly broad scope for monitoring components of the chart, where it would e.g. watch all `component: bookie` pods, even those not generated by this chart. This is also fixed with this pull request.

### Modifications

I've updated all labelSelector: -elements that I could find to use `pulsar.matchLabels` instead of hardcoded app + release labels.

Additionally, I've narrowed the scope of the various PodMonitor resources to only watch resources that should have been generated by this release, such that a PodMonitor for this chart does not also monitor another chart (as that would be extra load on the servers).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
