### PR TITLE
add enableAdminApi for prometheus

### DIFF
--- a/charts/pulsar/templates/prometheus-deployment.yaml
+++ b/charts/pulsar/templates/prometheus-deployment.yaml
@@ -59,6 +59,10 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
         image: "{{ .Values.images.prometheus.repository }}:{{ .Values.images.prometheus.tag }}"
         imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}
+        {{- if .Values.prometheus.enableAdminApi }}
+        args:
+          - --web.enable-admin-api
+        {{- end }}
       {{- if .Values.prometheus.resources }}
         resources:
 {{ toYaml .Values.prometheus.resources | indent 10 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -872,6 +872,7 @@ prometheus:
   tolerations: []
   gracePeriod: 5
   port: 9090
+  enableAdminApi: false
   resources:
     requests:
       memory: 256Mi


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

would be nice to have this option here so people can run admin commands against the prometheus. 

### Modifications

added a new value and modified the deployment, taken from the official prom helm.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
