### PR TITLE
WIP: Prevent breaking changes when using non-root container image for 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ It includes support for:
         - [ ] Mutal TLS
         - [ ] Kerberos
     - [x] Authorization
+    - [x] Run component containers as a non-root user
 - [x] Storage
     - [x] Non-persistence storage
     - [x] Persistence Volume
@@ -183,6 +184,28 @@ helm upgrade -f pulsar.yaml \
 ```
 
 For more detailed information, see our [Upgrading](http://pulsar.apache.org/docs/en/helm-upgrade/) guide.
+
+### Upgrading to use the rootless container image
+
+The Apache Pulsar Docker image for version 2.8.0 runs as user `10000`, by default. In order to prevent breaking
+changes during upgrade, this helm chart overrides this default user for the Bookkeeper and ZooKeeper
+components by running them as the root user. These components each need write access to `/pulsar/data` (by default)
+in order to function properly.
+
+You can upgrade an existing cluster to run these components with the non-root user by changing the ownership of all
+relevant directories and files before upgrading to 2.8.0. You will also need to modify the Helm values for each component.
+
+If already have a running pulsar cluster with ZK and BK running as the root user, you can change the ownership of these
+files while your components are running. Assuming you have the default directories configured for these components, the
+following scripts should be sufficient for ensuring a seamless upgrade:
+
+1. Zookeeper: `$ chown -r 10000:10001 /pulsar/data/zookeeper`
+1. Bookkeeper: `$ chown -r 10000:10001 /pulsar/data`
+
+Note that if you are running on `OpenShift`, you'll want to use the same directories, but instead run the following:
+
+1. Zookeeper: `$ chmod -R g=u /pulsar/data/zookeeper`
+1. Bookkeeper: `$ chmod -R g=u /pulsar/data`
 
 ## Uninstall
 

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -101,6 +101,10 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
+    {{- if .Values.bookkeeper.securityContext }}
+      securityContext:
+{{ toYaml .Values.bookkeeper.securityContext | indent 8 }}
+    {{- end }}
     {{- if and .Values.rbac.enabled .Values.rbac.psp }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
     {{- end}}

--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -31,7 +31,7 @@ data:
   httpNumThreads: "8"
   statusFilePath: "{{ template "pulsar.home" . }}/status"
   # prometheus needs to access /metrics endpoint
-  webServicePort: "{{ .Values.proxy.ports.http }}"
+  webServicePort: "{{ .Values.proxy.ports.httpTarget }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
   servicePort: "{{ .Values.proxy.ports.pulsar }}"
   brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -36,6 +36,7 @@ spec:
     {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
     - name: http
       port: {{ .Values.proxy.ports.http }}
+      targetPort: {{ .Values.proxy.ports.httpTarget }}
       protocol: TCP
     - name: pulsar
       port: {{ .Values.proxy.ports.pulsar }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         component: {{ .Values.proxy.component }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.proxy.ports.http }}"
+        prometheus.io/port: "{{ .Values.proxy.ports.httpTarget }}"
         {{- if .Values.proxy.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
         {{- end }}
@@ -145,7 +145,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /status.html
-            port: {{ .Values.proxy.ports.http }}
+            port: {{ .Values.proxy.ports.httpTarget }}
           initialDelaySeconds: {{ .Values.proxy.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.liveness.periodSeconds }}
           failureThreshold: {{ .Values.proxy.probe.liveness.failureThreshold }}
@@ -154,7 +154,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /status.html
-            port: {{ .Values.proxy.ports.http }}
+            port: {{ .Values.proxy.ports.httpTarget }}
           initialDelaySeconds: {{ .Values.proxy.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.readiness.periodSeconds }}
           failureThreshold: {{ .Values.proxy.probe.readiness.failureThreshold }}
@@ -163,7 +163,7 @@ spec:
         startupProbe:
           httpGet:
             path: /status.html
-            port: {{ .Values.proxy.ports.http }}
+            port: {{ .Values.proxy.ports.httpTarget }}
           initialDelaySeconds: {{ .Values.proxy.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.startup.periodSeconds }}
           failureThreshold: {{ .Values.proxy.probe.startup.failureThreshold }}
@@ -181,7 +181,7 @@ spec:
         ports:
         # prometheus needs to access /metrics endpoint
         - name: http
-          containerPort: {{ .Values.proxy.ports.http }}
+          containerPort: {{ .Values.proxy.ports.httpTarget }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
         - name: pulsar
           containerPort: {{ .Values.proxy.ports.pulsar }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -98,6 +98,10 @@ spec:
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
+    {{- if .Values.zookeeper.securityContext }}
+      securityContext:
+{{ toYaml .Values.zookeeper.securityContext | indent 8 }}
+    {{- end }}
     {{- if and .Values.rbac.enabled .Values.rbac.psp }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
     {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -287,6 +287,11 @@ zookeeper:
     scrapeTimeout: 10s
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
+  # Starting in 2.8.0, the Apache Pulsar docker image defaults to run as the pulsar user, see README for
+  # instructions on upgrading a bookie to run as a rootless container.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
   ports:
     http: 8000
     client: 2181
@@ -401,6 +406,11 @@ bookkeeper:
     scrapeTimeout: 10s
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
+  # Starting in 2.8.0, the Apache Pulsar docker image defaults to run as the pulsar user, see README for
+  # instructions on upgrading a bookie to run as a rootless container.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
   ports:
     http: 8000
     bookie: 3181
@@ -678,6 +688,11 @@ broker:
 ##
 functions:
   component: functions-worker
+  # Starting in 2.8.0, the Apache Pulsar docker image defaults to run as the pulsar user, see README for
+  # instructions on upgrading a bookie to run as a rootless container.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
 
 ## Pulsar: Proxy Cluster
 ## templates/proxy-statefulset.yaml
@@ -752,6 +767,7 @@ proxy:
   ##
   ports:
     http: 80
+    httpTarget: 8080
     https: 443
     pulsar: 6650
     pulsarssl: 6651


### PR DESCRIPTION
Fixes #110

### Motivation

The 2.8.0 pulsar docker image defaults to run as user id `10000`. This will break end user deployments unless we modify the helm chart.

Note, I have an outstanding question about how pulsar functions are deployed with this helm chart. I haven't used the helm chart to deploy functions, so I'm not sure what is required to ensure that functions work before and after the upgrade. We'll need to solve this before merging the PR.

### Modifications

1. Run bookies as root by default.
2. Run zookeeper as root by default.
3. Update the proxy service to route traffic from port 80 to port 8080 by default.

### Verifying this change

I deployed this change on a local minikube cluster to make sure things looked as expected. The bookies and zookeepers run as the root user, and the proxy service maps the port from 80 to 8080. 