### PR TITLE
Antiaffinity with zone topology for high availability 

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -67,6 +67,7 @@ spec:
         podAntiAffinity:
           {{ if eq .Values.autorecovery.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.autorecovery.affinity.type }}:
+          {{- if .Values.autorecovery.affinity.anti_affinity_topology.host.enabled}}
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -82,9 +83,28 @@ spec:
                 values:
                 - {{ .Values.autorecovery.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.autorecovery.affinity.anti_affinity_topology.zone.enabled}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.autorecovery.component }}
+            topologyKey: "topology.kubernetes.io/zone"
+          {{- end }}
         {{ else }}
           {{ .Values.autorecovery.affinity.type }}:
-            - weight: 100
+            {{- if .Values.autorecovery.affinity.anti_affinity_topology.host.enabled}}
+            - weight: {{ .Values.autorecovery.affinity.anti_affinity_topology.host.weight }}
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -101,6 +121,26 @@ spec:
                       values:
                       - {{ .Values.autorecovery.component }}
                 topologyKey: "kubernetes.io/hostname"
+            {{- end }}
+            {{- if .Values.autorecovery.affinity.anti_affinity_topology.zone.enabled}}
+            - weight: {{ .Values.autorecovery.affinity.anti_affinity_topology.zone.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.autorecovery.component }}
+                topologyKey: "topology.kubernetes.io/zone"
+            {{- end }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.autorecovery.gracePeriod }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -64,6 +64,7 @@ spec:
         podAntiAffinity:
           {{ if eq .Values.bookkeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.bookkeeper.affinity.type }}:
+          {{- if .Values.bookkeeper.affinity.anti_affinity_topology.host.enabled}}
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -79,9 +80,28 @@ spec:
                 values:
                 - {{ .Values.bookkeeper.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.bookkeeper.affinity.anti_affinity_topology.zone.enabled}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.bookkeeper.component }}
+            topologyKey: "topology.kubernetes.io/zone"
+          {{- end }}
         {{ else }}
           {{ .Values.bookkeeper.affinity.type }}:
-            - weight: 100
+            {{- if .Values.bookkeeper.affinity.anti_affinity_topology.host.enabled}}
+            - weight: {{ .Values.bookkeeper.affinity.anti_affinity_topology.host.weight }}
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -98,6 +118,26 @@ spec:
                       values:
                       - {{ .Values.bookkeeper.component }}
                 topologyKey: "kubernetes.io/hostname"
+            {{- end }}
+            {{- if .Values.bookkeeper.affinity.anti_affinity_topology.zone.enabled}}
+            - weight: {{ .Values.bookkeeper.affinity.anti_affinity_topology.zone.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.bookkeeper.component }}
+                topologyKey: "topology.kubernetes.io/zone"
+            {{- end }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -65,6 +65,7 @@ spec:
         podAntiAffinity:
           {{ if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.broker.affinity.type }}:
+          {{- if .Values.broker.affinity.anti_affinity_topology.host.enabled}}
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -80,9 +81,28 @@ spec:
                 values:
                 - {{ .Values.broker.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.broker.affinity.anti_affinity_topology.zone.enabled}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.broker.component }}
+            topologyKey: "topology.kubernetes.io/zone"
+          {{- end }}
         {{ else }}
           {{ .Values.broker.affinity.type }}:
-            - weight: 100
+            {{- if .Values.broker.affinity.anti_affinity_topology.host.enabled}}
+            - weight: {{ .Values.broker.affinity.anti_affinity_topology.host.weight }}
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -99,6 +119,26 @@ spec:
                       values:
                       - {{ .Values.broker.component }}
                 topologyKey: "kubernetes.io/hostname"
+            {{- end }}
+            {{- if .Values.broker.affinity.anti_affinity_topology.zone.enabled}}
+            - weight: {{ .Values.broker.affinity.anti_affinity_topology.zone.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.broker.component }}
+                topologyKey: "topology.kubernetes.io/zone"
+            {{- end }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.broker.gracePeriod }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -64,6 +64,7 @@ spec:
         podAntiAffinity:
         {{ if eq .Values.proxy.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.proxy.affinity.type }}:
+          {{- if .Values.proxy.affinity.anti_affinity_topology.host.enabled}}
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -79,9 +80,28 @@ spec:
                 values:
                 - {{ .Values.proxy.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+          {{- if .Values.proxy.affinity.anti_affinity_topology.zone.enabled}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.proxy.component }}
+            topologyKey: "topology.kubernetes.io/zone"
+          {{- end }}
         {{ else }}
           {{ .Values.proxy.affinity.type }}:
-            - weight: 100
+            {{- if .Values.proxy.affinity.anti_affinity_topology.host.enabled}}
+            - weight: {{ .Values.proxy.affinity.anti_affinity_topology.host.weight }}
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -98,6 +118,26 @@ spec:
                       values:
                       - {{ .Values.proxy.component }}
                 topologyKey: "kubernetes.io/hostname"
+          {{- end }}
+            {{- if .Values.proxy.affinity.anti_affinity_topology.zone.enabled}}
+            - weight: {{ .Values.proxy.affinity.anti_affinity_topology.zone.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.proxy.component }}
+                topologyKey: "topology.kubernetes.io/zone"
+            {{- end }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -61,6 +61,7 @@ spec:
         podAntiAffinity:
           {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.zookeeper.affinity.type }}:
+          {{- if .Values.zookeeper.affinity.anti_affinity_topology.host.enabled}}
           - labelSelector:
               matchExpressions:
               - key: "app"
@@ -76,9 +77,28 @@ spec:
                 values:
                 - {{ .Values.zookeeper.component }}
             topologyKey: "kubernetes.io/hostname"
+          {{ end }}
+          {{- if .Values.zookeeper.affinity.anti_affinity_topology.zone.enabled}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.zookeeper.component }}
+            topologyKey: "topology.kubernetes.io/zone"
+          {{- end }}
         {{ else }}
           {{ .Values.zookeeper.affinity.type }}:
-            - weight: 100
+            {{- if .Values.zookeeper.affinity.anti_affinity_topology.host.enabled}}
+            - weight: {{ .Values.zookeeper.affinity.anti_affinity_topology.host.weight }}
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -95,6 +115,26 @@ spec:
                       values:
                       - {{ .Values.zookeeper.component }}
                 topologyKey: "kubernetes.io/hostname"
+            {{- end }}
+            {{- if .Values.zookeeper.affinity.anti_affinity_topology.zone.enabled}}
+            - weight: {{ .Values.zookeeper.affinity.anti_affinity_topology.zone.weight }}
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.zookeeper.component }}
+                topologyKey: "topology.kubernetes.io/zone"
+            {{- end }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -334,6 +334,15 @@ zookeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    anti_affinity_topology:
+     host:
+      enabled: true
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 100
+     zone:
+      enabled: false
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 60
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8000"
@@ -461,6 +470,15 @@ bookkeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    anti_affinity_topology:
+     host:
+      enabled: true
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 100
+     zone:
+      enabled: false
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 60
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -590,6 +608,15 @@ autorecovery:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    anti_affinity_topology:
+     host:
+      enabled: true
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 100
+     zone:
+      enabled: false
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 60 
   annotations: {}
   # tolerations: []
   gracePeriod: 30
@@ -675,6 +702,15 @@ broker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: preferredDuringSchedulingIgnoredDuringExecution
+    anti_affinity_topology:
+     host:
+      enabled: true
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 100
+     zone:
+      enabled: false
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 60
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -784,6 +820,15 @@ proxy:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    anti_affinity_topology:
+     host:
+      enabled: true
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 100
+     zone:
+      enabled: false
+      # weight applies only if type: preferredDuringSchedulingIgnoredDuringExecution
+      weight: 60
   annotations: {}
   tolerations: []
   gracePeriod: 30


### PR DESCRIPTION
### Motivation

There is no option in the current helm chart to make the pulsar high available. With this pull request, we can make some of the pulsar components highly available (multiAZ support). This is usually a requirement by many companies and I believe it will help many people that are facing this limitation. This version is backwards compatible, the default values are the same. It is tested and works as expected, pods can be scheduled in different availability zones if `<component>.affinity.anti_affinity_topology.zone.enabled: true`

### Modifications

I have added an extra option in the anti-affinity section for multiAZ support (disabled by default), this future is applied to bookkeeper, proxy, zookeeper, auto-recovery, and broker and is almost the same code for all of them. Made the weight from static value to variable (defaults are not changed), so users can adjust the weight in case they want to use both `host` and `zone` anti-affinity 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
