### PR TITLE
Updates internal issuer cert to include common fields

### DIFF
--- a/charts/pulsar/templates/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls-cert-internal-issuer.yaml
@@ -36,6 +36,8 @@ metadata:
 spec:
   secretName: "{{ .Release.Name }}-ca-tls"
   commonName: "{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+  duration: "{{ .Values.certs.internal_issuer.duration }}"
+  renewBefore: "{{ .Values.certs.internal_issuer.renewBefore }}"
   usages:
     - server auth
     - client auth

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -260,6 +260,10 @@ certs:
     enabled: false
     component: internal-cert-issuer
     type: selfsigning
+    # 90d
+    duration: 2160h
+    # 15d
+    renewBefore: 360h
   issuers:
     selfsigning:
 


### PR DESCRIPTION
### Motivation
* While component certs can be configured with a custom duration the CA cert for self-signed configuration uses default values. It can be convenient to have this certificate expire more than a month out.

### Modifications
* Updates the internal issuer `{{ .Release.Name }}-ca-tls` certificate to make `duration` and `renewBefore` configurable. Does not use `common` so that the CA can be configured to last much longer than individual components certs if desired.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
