### PR TITLE
Fix deprecation warning about rbac.authorization.k8s.io/v1beta1

### DIFF
--- a/charts/pulsar/templates/autorecovery-rbac.yaml
+++ b/charts/pulsar/templates/autorecovery-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
@@ -41,7 +41,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"

--- a/charts/pulsar/templates/bookkeeper-rbac.yaml
+++ b/charts/pulsar/templates/bookkeeper-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
@@ -41,7 +41,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -39,7 +39,7 @@ subjects:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"

--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if or .Values.components.functions .Values.extra.functionsAsPods }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
@@ -45,7 +45,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
@@ -63,7 +63,7 @@ subjects:
 ---
 
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"
@@ -79,7 +79,7 @@ rules:
       - use
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-psp"

--- a/charts/pulsar/templates/prometheus-rbac.yaml
+++ b/charts/pulsar/templates/prometheus-rbac.yaml
@@ -19,7 +19,7 @@
 
 {{- if or .Values.monitoring.prometheus .Values.extra.monitoring }}
 {{- if or .Values.prometheus.rbac.enabled .Values.prometheus_rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"

--- a/charts/pulsar/templates/proxy-rbac.yaml
+++ b/charts/pulsar/templates/proxy-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
@@ -41,7 +41,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/toolset-rbac.yaml
+++ b/charts/pulsar/templates/toolset-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
@@ -41,7 +41,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"

--- a/charts/pulsar/templates/zookeeper-rbac.yaml
+++ b/charts/pulsar/templates/zookeeper-rbac.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if and .Values.rbac.enabled .Values.rbac.psp }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
@@ -41,7 +41,7 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"


### PR DESCRIPTION
### Motivation

Installing with helm shows this type of warning
```
W0624 17:14:41.741744 3044383 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
```

### Modifications

Apply the fix suggested in the warning message.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
