### PR TITLE
Bump containers to sync with Streamnative & Pulsar version to 2.8.0

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: "2.7.2"
+appVersion: "2.8.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.2
+version: 2.8.0
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -149,38 +149,38 @@ extra:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
     pullPolicy: IfNotPresent
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
     pullPolicy: IfNotPresent
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
     pullPolicy: IfNotPresent
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
     pullPolicy: IfNotPresent
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
     pullPolicy: IfNotPresent
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.0
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.10
+    tag: 0.0.14
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager
-    tag: v0.1.0
+    tag: v0.2.0
     pullPolicy: IfNotPresent
     hasCommand: false
 


### PR DESCRIPTION
### Motivation

2.8.0 has been released for two weeks and it is probably time to bump the versions here.

### Modifications

Bump versions of containers for Pulsar v2.8. Also bump the grafana dashboards to be in sync with the streamnative ones and there is a newer tag of pulsar manager.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
