### PR TITLE
automate initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,8 @@ helm repo add apache https://pulsar.apache.org/charts
 
 To use the helm chart:
 
-> NOTE: Please specify `--set initialize=true` when installing a release at the first time. `initialize=true` will start initialize jobs
->       to initialize the cluster metadata for both bookkeeper and pulsar clusters.
-
 ```bash
-helm install --set initialize=true <release-name> apache/pulsar
+helm install <release-name> apache/pulsar
 ```
 
 ## Kubernetes cluster preparation

--- a/README.md
+++ b/README.md
@@ -130,13 +130,10 @@ We provide some instructions to guide you through the preparation: http://pulsar
 
 3. Use the Pulsar Helm charts to install Apache Pulsar. 
 
-> NOTE: Please specify `--set initialize=true` when installing a release at the first time. `initialize=true` will start initialize jobs
->       to initialize the cluster metadata for both bookkeeper and pulsar clusters.
-
     This command installs and starts Apache Pulsar.
 
     ```bash 
-    $ helm install --set initialize=true <pulsar-release-name> apache/pulsar
+    $ helm install <pulsar-release-name> apache/pulsar
     ```
 
 5. Access the Pulsar cluster

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-{{- if .Release.IsInstall }}
+{{- if or .Release.IsInstall .Values.initialize }}
 {{- if .Values.components.bookkeeper }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-{{- if .Values.initialize }}
+{{- if .Release.IsInstall }}
 {{- if .Values.components.bookkeeper }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Release.IsInstall }}
+{{- if or .Release.IsInstall .Values.initialize }}
 {{- if .Values.components.broker }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.initialize }}
+{{- if .Release.IsInstall }}
 {{- if .Values.components.broker }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -34,6 +34,9 @@ clusterDomain: cluster.local
 ### Global Settings
 ###
 
+## Set to true on install
+initialize: false
+
 ## Set cluster name
 # clusterName:
 

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -34,9 +34,6 @@ clusterDomain: cluster.local
 ### Global Settings
 ###
 
-## Set to true on install
-initialize: false
-
 ## Set cluster name
 # clusterName:
 


### PR DESCRIPTION
Fixes #114

### Motivation

Having `initialize` value that must be manually set is prone to human error, there is a risk of running init again forcing the need of a rollback.

### Modifications

Using Helm capability to understand if it's an install or upgrade we can avoid to launch init when not needed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
