### PR TITLE
Updates CA name generation to be configurable

### DIFF
--- a/charts/pulsar/templates/_autorecovery.tpl
+++ b/charts/pulsar/templates/_autorecovery.tpl
@@ -55,7 +55,7 @@ Define autorecovery tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
     items:
     - key: ca.crt
       path: ca.crt

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -56,7 +56,7 @@ Define bookie tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
     items:
     - key: ca.crt
       path: ca.crt

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -62,7 +62,7 @@ Define broker tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
     items:
     - key: ca.crt
       path: ca.crt

--- a/charts/pulsar/templates/_toolset.tpl
+++ b/charts/pulsar/templates/_toolset.tpl
@@ -55,7 +55,7 @@ Define toolset tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
     items:
     - key: ca.crt
       path: ca.crt

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -253,7 +253,7 @@ spec:
         {{- if .Values.tls.proxy.enabled }}
         - name: ca
           secret:
-            secretName: "{{ .Release.Name }}-ca-tls"
+            secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
             items:
               - key: ca.crt
                 path: ca.crt

--- a/charts/pulsar/templates/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls-cert-internal-issuer.yaml
@@ -34,7 +34,7 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-ca"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
-  secretName: "{{ .Release.Name }}-ca-tls"
+  secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
   commonName: "{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}"
   duration: "{{ .Values.certs.internal_issuer.duration }}"
   renewBefore: "{{ .Values.certs.internal_issuer.renewBefore }}"
@@ -59,6 +59,6 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   ca:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
       {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled .Values.tls.proxy.enabled) }}
       - name: proxy-ca
         secret:
-          secretName: "{{ .Release.Name }}-ca-tls"
+          secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
           items:
             - key: ca.crt
               path: ca.crt

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -199,7 +199,7 @@ spec:
               path: tls.key
       - name: ca
         secret:
-          secretName: "{{ .Release.Name }}-ca-tls"
+          secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
           items:
             - key: ca.crt
               path: ca.crt

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -191,6 +191,7 @@ images:
 ## brokers and proxies.
 tls:
   enabled: false
+  ca_suffix: ca-tls
   # common settings for generating certs
   common:
     # 90d

--- a/scripts/pulsar/clean_tls.sh
+++ b/scripts/pulsar/clean_tls.sh
@@ -25,6 +25,7 @@ cd ${CHART_HOME}
 
 namespace=${namespace:-pulsar}
 release=${release:-pulsar-dev}
+caSuffix=${caSuffix:-ca-tls}
 clientComponents=${clientComponents:-"toolset"}
 serverComponents=${serverComponents:-"bookie,broker,proxy,recovery,zookeeper"}
 
@@ -35,6 +36,7 @@ Options:
        -h,--help                        prints the usage message
        -n,--namespace                   the k8s namespace to install the pulsar helm chart. Defaut to ${namespace}.
        -k,--release                     the pulsar helm release name. Default to ${release}.
+       -ca,--ca-suffix                  the suffix used to name the CA certificate. Default to ${caSuffix}.
        -c,--client-components           the client components of pulsar cluster. a comma separated list of components. Default to ${clientComponents}.
        -s,--server-components           the server components of pulsar cluster. a comma separated list of components. Default to ${serverComponents}.
 Usage:
@@ -54,6 +56,11 @@ case $key in
     ;;
     -k|--release)
     release="$2"
+    shift
+    shift
+    ;;
+    -ca|--ca-suffix)
+    caSuffix="$2"
     shift
     shift
     ;;
@@ -80,7 +87,7 @@ esac
 done
 
 function delete_ca() {
-    local tls_ca_secret="${release}-ca-tls"
+    local tls_ca_secret="${release}-${caSuffix}"
     kubectl delete secret ${tls_ca_secret} -n ${namespace}
 }
 

--- a/scripts/pulsar/upload_tls.sh
+++ b/scripts/pulsar/upload_tls.sh
@@ -25,6 +25,7 @@ cd ${CHART_HOME}
 
 namespace=${namespace:-pulsar}
 release=${release:-pulsar-dev}
+caSuffix=${caSuffix:-ca-tls}
 tlsdir=${tlsdir:-"${HOME}/.config/pulsar/security_tool/gen/ca"}
 clientComponents=${clientComponents:-""}
 serverComponents=${serverComponents:-"bookie,broker,proxy,recovery,zookeeper,toolset"}
@@ -37,6 +38,7 @@ Options:
        -h,--help                        prints the usage message
        -n,--namespace                   the k8s namespace to install the pulsar helm chart. Defaut to ${namespace}.
        -k,--release                     the pulsar helm release name. Default to ${release}.
+       -ca,--ca-suffix                  the suffix used to name the CA certificate. Default to ${caSuffix}.
        -d,--dir                         the dir for storing tls certs. Default to ${tlsdir}.
        -c,--client-components           the client components of pulsar cluster. a comma separated list of components. Default to ${clientComponents}.
        -s,--server-components           the server components of pulsar cluster. a comma separated list of components. Default to ${serverComponents}.
@@ -58,6 +60,11 @@ case $key in
     ;;
     -k|--release)
     release="$2"
+    shift
+    shift
+    ;;
+    -ca|--ca-suffix)
+    caSuffix="$2"
     shift
     shift
     ;;
@@ -95,7 +102,7 @@ done
 ca_cert_file=${tlsdir}/certs/ca.cert.pem
 
 function upload_ca() {
-    local tls_ca_secret="${release}-ca-tls"
+    local tls_ca_secret="${release}-${caSuffix}"
     kubectl create secret generic ${tls_ca_secret} -n ${namespace} --from-file="ca.crt=${ca_cert_file}" ${local:+ -o yaml --dry-run=client}
 }
 


### PR DESCRIPTION
Updates CA name generation to be configurable allowing the swapping in of a CA.

### Motivation

We recently swapped out cert issuers and found that with the current helm chart we were unable to do a hot swap without downtime (via helm) because the CA cert name is not configurable. Being able to change the name of the CA allows us to create a new CA first -> Validate -> then swap over in follow up apply/release.

### Modifications

Adds the ability to specify the suffix used to generate the CA name (not the whole name in order to preserve back compatibility regardless of the release name.)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
