### PR TITLE
ZooKeeper HTTP port should be exposed by service so we can use promet…

### DIFF
--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -31,6 +31,9 @@ metadata:
 {{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
 spec:
   ports:
+    # prometheus needs to access /metrics endpoint
+    - name: http
+      port: {{ .Values.zookeeper.ports.http }}
     - name: follower
       port: {{ .Values.zookeeper.ports.follower }}
     - name: leader-election


### PR DESCRIPTION
…heus

Fixes #142 

### Motivation

Expose HTTP Port on ZooKeeper service so we can use Prometheus

### Modifications

Bug fix to expose HTTP port on ZooKeeper service

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
