### PR TITLE
added additionalCommand parameter

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -165,6 +165,9 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+        {{- if .Values.bookkeeper.additionalCommand }}
+          {{ .Values.bookkeeper.additionalCommand }}
+        {{- end }}
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -198,6 +198,9 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+        {{- if .Values.broker.additionalCommand }}
+          {{ .Values.broker.additionalCommand }}
+        {{- end }}
           bin/apply-config-from-env.py conf/broker.conf;
           bin/gen-yml-from-env.py conf/functions_worker.yml;
           echo "OK" > status;

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -178,6 +178,9 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+        {{- if .Values.proxy.additionalCommand }}
+          {{ .Values.proxy.additionalCommand }}
+        {{- end }}
           bin/apply-config-from-env.py conf/proxy.conf &&
           echo "OK" > status &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+        {{- if .Values.toolset.additionalCommand }}
+          {{ .Values.toolset.additionalCommand }}
+        {{- end }}
           bin/apply-config-from-env.py conf/client.conf;
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 10 }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -112,6 +112,9 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+        {{- if .Values.zookeeper.additionalCommand }}
+          {{ .Values.zookeeper.additionalCommand }}
+        {{- end }}
           bin/apply-config-from-env.py conf/zookeeper.conf;
           {{- include "pulsar.zookeeper.tls.settings" . | nindent 10 }}
           bin/generate-zookeeper-config.sh conf/zookeeper.conf;

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -390,6 +390,8 @@ zookeeper:
       -XX:+DoEscapeAnalysis
       -XX:+DisableExplicitGC
       -XX:+PerfDisableSharedMem
+  ## Add a custom command to the start up process of the zookeeper pods (e.g. update-ca-certificates, jvm commands, etc)
+  additionalCommand:
   ## Zookeeper service
   ## templates/zookeeper-service.yaml
   ##
@@ -551,6 +553,8 @@ bookkeeper:
     dbStorage_readAheadCacheMaxSizeMb: "32"
     dbStorage_rocksDB_writeBufferSizeMB: "8"
     dbStorage_rocksDB_blockCacheSize: "8388608"
+  ## Add a custom command to the start up process of the bookie pods (e.g. update-ca-certificates, jvm commands, etc)
+  additionalCommand:
   ## Bookkeeper Service
   ## templates/bookkeeper-service.yaml
   ##
@@ -719,6 +723,8 @@ broker:
     managedLedgerDefaultEnsembleSize: "2"
     managedLedgerDefaultWriteQuorum: "2"
     managedLedgerDefaultAckQuorum: "2"
+  ## Add a custom command to the start up process of the broker pods (e.g. update-ca-certificates, jvm commands, etc)
+  additionalCommand:
   ## Broker service
   ## templates/broker-service.yaml
   ##
@@ -825,6 +831,8 @@ proxy:
       -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
+  ## Add a custom command to the start up process of the proxy pods (e.g. update-ca-certificates, jvm commands, etc)
+  additionalCommand:
   ## Proxy service
   ## templates/proxy-service.yaml
   ##
@@ -939,6 +947,8 @@ toolset:
       -Xms64M
       -Xmx128M
       -XX:MaxDirectMemorySize=128M
+  ## Add a custom command to the start up process of the toolset pods (e.g. update-ca-certificates, jvm commands, etc)
+  additionalCommand:
 
 #############################################################
 ### Monitoring Stack : Prometheus / Grafana


### PR DESCRIPTION
Fixes #148 

### Motivation
Added a `additionalCommand` parameter for each statefulset so that the chart user can optionally specific a custom command such as `update-ca-certificates` to run prior to starting the JVM and other container processes. This is required to avoid custom image builds simply for shipping an internal CA certificate file.

### Modifications
* Added `additionalCommand` parameter to values.yaml for each statefulset
* Added conditionals to each statefulset allowing the chart user to specify a command to be ran at the beginning of the command line(s)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
