### PR TITLE
Define configuration store settings on proxy configmap

### DIFF
--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -27,6 +27,15 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
 data:
+  # Metadata settings
+  zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- if .Values.pulsar_metadata.configurationStore }}
+  configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  {{- end }}
+  {{- if not .Values.pulsar_metadata.configurationStore }}
+  configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- end }}
+
   clusterName: {{ template "pulsar.cluster.name" . }}
   httpNumThreads: "8"
   statusFilePath: "{{ template "pulsar.home" . }}/status"


### PR DESCRIPTION
### Motivation

This is required to active websockets and while it can be provided via
proxy.configData this is more ergonomic for users of the chart.

### Modifications

Added zookeeperServers/configurationStoreServers to proxy config map

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
