### PR TITLE
Fix #152 Helm chart does not support Istio port naming

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.2
+version: 2.7.2.1
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper-service.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   ports:
   - name: bookie
-    port: {{ .Values.bookkeeper.ports.bookie }}
+    port: {{ .Values.bookkeeper.ports.tcp-bookie }}
   - name: http
     port: {{ .Values.bookkeeper.ports.http }}
   clusterIP: None

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -170,8 +170,8 @@ spec:
           readOnlyRootFilesystem: false
       {{- end}}
         ports:
-        - name: bookie
-          containerPort: {{ .Values.bookkeeper.ports.bookie }}
+        - name: tcp-bookie
+          containerPort: {{ .Values.bookkeeper.ports.tcp-bookie }}
         - name: http
           containerPort: {{ .Values.bookkeeper.ports.http }}
         envFrom:

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -65,11 +65,11 @@ data:
   PF_functionRuntimeFactoryConfigs_expectedMetricsCollectionInterval: "30"
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
   PF_functionRuntimeFactoryConfigs_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
-  PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}/"
+  PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tcp-pulsar }}/"
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   PF_functionRuntimeFactoryConfigs_pulsarAdminUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}/"
-  PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
+  PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tls-pulsarssl }}/"
   {{- end }}
   PF_functionRuntimeFactoryConfigs_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
   PF_functionRuntimeFactoryConfigs_changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
@@ -81,11 +81,11 @@ data:
   PF_kubernetesContainerFactory_expectedMetricsCollectionInterval: "30"
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
   PF_kubernetesContainerFactory_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
-  PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}/"
+  PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tcp-pulsar }}/"
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   PF_kubernetesContainerFactory_pulsarAdminUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}/"
-  PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
+  PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tls-pulsarssl }}/"
   {{- end }}
   PF_kubernetesContainerFactory_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
   PF_kubernetesContainerFactory_changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
@@ -94,10 +94,10 @@ data:
   # prometheus needs to access /metrics endpoint
   webServicePort: "{{ .Values.broker.ports.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-  brokerServicePort: "{{ .Values.broker.ports.pulsar }}"
+  brokerServicePort: "{{ .Values.broker.ports.tcp-pulsar }}"
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
-  brokerServicePortTls: "{{ .Values.broker.ports.pulsarssl }}"
+  brokerServicePortTls: "{{ .Values.broker.ports.tls-pulsarssl }}"
   webServicePortTls: "{{ .Values.broker.ports.https }}"
   # TLS Settings
   tlsCertificateFilePath: "/pulsar/certs/broker/tls.crt"

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -34,14 +34,14 @@ spec:
   - name: http
     port: {{ .Values.broker.ports.http }}
   {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-  - name: pulsar
-    port: {{ .Values.broker.ports.pulsar }}
+  - name: tcp-pulsar
+    port: {{ .Values.broker.ports.tcp-pulsar }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   - name: https
     port: {{ .Values.broker.ports.https }}
-  - name: pulsarssl
-    port: {{ .Values.broker.ports.pulsarssl }}
+  - name: tls-pulsarssl
+    port: {{ .Values.broker.ports.tls-pulsarssl }}
   {{- end }}
   clusterIP: None
   selector:

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -212,14 +212,14 @@ spec:
         - name: http
           containerPort: {{ .Values.broker.ports.http }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-        - name: pulsar
-          containerPort: {{ .Values.broker.ports.pulsar }}
+        - name: tcp-pulsar
+          containerPort: {{ .Values.broker.ports.tcp-pulsar }}
         {{- end }}
         {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
         - name: https
           containerPort: {{ .Values.broker.ports.https }}
-        - name: pulsarssl
-          containerPort: {{ .Values.broker.ports.pulsarssl }}
+        - name: tls-pulsarssl
+          containerPort: {{ .Values.broker.ports.tls-pulsarssl }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -33,27 +33,27 @@ data:
   # prometheus needs to access /metrics endpoint
   webServicePort: "{{ .Values.proxy.ports.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
-  servicePort: "{{ .Values.proxy.ports.pulsar }}"
-  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}
+  servicePort: "{{ .Values.proxy.ports.tcp-pulsar }}"
+  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tcp-pulsar }}
   brokerWebServiceURL: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
   tlsEnabledInProxy: "true"
-  servicePortTls: "{{ .Values.proxy.ports.pulsarssl }}"
+  servicePortTls: "{{ .Values.proxy.ports.tls-pulsarssl }}"
   webServicePortTls: "{{ .Values.proxy.ports.https }}"
   tlsCertificateFilePath: "/pulsar/certs/proxy/tls.crt"
   tlsKeyFilePath: "/pulsar/certs/proxy/tls.key"
   tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   # if broker enables TLS, configure proxy to talk to broker using TLS
-  brokerServiceURLTLS: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}
+  brokerServiceURLTLS: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tls-pulsarssl }}
   brokerWebServiceURLTLS: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}
   tlsEnabledWithBroker: "true"
   tlsCertRefreshCheckDurationSec: "300"
   brokerClientTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
-  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}
+  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tcp-pulsar }}
   brokerWebServiceURL: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}
   {{- end }}
   {{- end }}

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,16 +37,16 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
-    - name: pulsar
-      port: {{ .Values.proxy.ports.pulsar }}
+    - name: tcp-pulsar
+      port: {{ .Values.proxy.ports.tcp-pulsar }}
       protocol: TCP
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
-    - name: pulsarssl
-      port: {{ .Values.proxy.ports.pulsarssl }}
+    - name: tls-pulsarssl
+      port: {{ .Values.proxy.ports.tls-pulsarssl }}
       protocol: TCP
     {{- end }}
   selector:

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -183,14 +183,14 @@ spec:
         - name: http
           containerPort: {{ .Values.proxy.ports.http }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
-        - name: pulsar
-          containerPort: {{ .Values.proxy.ports.pulsar }}
+        - name: tcp-pulsar
+          containerPort: {{ .Values.proxy.ports.tcp-pulsar }}
         {{- end }}
         {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
         - name: https
           containerPort: {{ .Values.proxy.ports.https }}
-        - name: pulsarssl
-          containerPort: {{ .Values.proxy.ports.pulsarssl }}
+        - name: tls-pulsarssl
+          containerPort: {{ .Values.proxy.ports.tls-pulsarssl }}
         {{- end }}
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}
         securityContext:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -99,8 +99,8 @@ spec:
               {{- end }}
               --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.http }}/ \
               --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.https }}/ \
-              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsar }}/ \
-              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsarssl }}/ || true;
+              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.tcp-pulsar }}/ \
+              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.tls-pulsarssl }}/ || true;
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:

--- a/charts/pulsar/templates/toolset-configmap.yaml
+++ b/charts/pulsar/templates/toolset-configmap.yaml
@@ -33,7 +33,7 @@ data:
   # talk to broker
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}/"
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tls-pulsarssl }}/"
   useTls: "true"
   tlsAllowInsecureConnection: "false"
   tlsTrustCertsFilePath: "/pulsar/certs/proxy-ca/ca.crt"
@@ -41,14 +41,14 @@ data:
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
   webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.tcp-pulsar }}/"
   {{- end }}
   {{- end }}
   {{- if .Values.toolset.useProxy }}
   # talk to proxy
   {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
   webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.https }}/"
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.pulsarssl }}/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.tls-pulsarssl }}/"
   useTls: "true"
   tlsAllowInsecureConnection: "false"
   tlsTrustCertsFilePath: "/pulsar/certs/proxy-ca/ca.crt"
@@ -56,7 +56,7 @@ data:
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.proxy.enabled) }}
   webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.http }}/"
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.pulsar }}/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.tcp-pulsar }}/"
   {{- end }}
   {{- end }}
   # Authentication Settings

--- a/charts/pulsar/templates/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper-configmap.yaml
@@ -33,8 +33,8 @@ data:
   serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
   # enable zookeeper tls
   {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-  secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
-  PULSAR_PREFIX_secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
+  secureClientPort: "{{ .Values.zookeeper.ports.tls-clientTls }}"
+  PULSAR_PREFIX_secureClientPort: "{{ .Values.zookeeper.ports.tls-clientTls }}"
   {{- end }}
 {{ toYaml .Values.zookeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -34,15 +34,15 @@ spec:
     # prometheus needs to access /metrics endpoint
     - name: http
       port: {{ .Values.zookeeper.ports.http }}
-    - name: follower
-      port: {{ .Values.zookeeper.ports.follower }}
-    - name: leader-election
-      port: {{ .Values.zookeeper.ports.leaderElection }}
-    - name: client
-      port: {{ .Values.zookeeper.ports.client }}
+    - name: tcp-follower
+      port: {{ .Values.zookeeper.ports.tcp-follower }}
+    - name: tcp-leader-election
+      port: {{ .Values.zookeeper.ports.tcp-leaderElection }}
+    - name: tcp-client
+      port: {{ .Values.zookeeper.ports.tcp-client }}
     {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-    - name: client-tls
-      port: {{ .Values.zookeeper.ports.clientTls }}
+    - name: tls-client
+      port: {{ .Values.zookeeper.ports.tls-clientTls }}
     {{- end }}
   clusterIP: None
   selector:

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -120,15 +120,15 @@ spec:
         # prometheus needs to access /metrics endpoint
         - name: http
           containerPort: {{ .Values.zookeeper.ports.http }}
-        - name: client
-          containerPort: {{ .Values.zookeeper.ports.client }}
-        - name: follower
-          containerPort: {{ .Values.zookeeper.ports.follower }}
-        - name: leader-election
-          containerPort: {{ .Values.zookeeper.ports.leaderElection }}
+        - name: tcp-client
+          containerPort: {{ .Values.zookeeper.ports.tcp-client }}
+        - name: tcp-follower
+          containerPort: {{ .Values.zookeeper.ports.tcp-follower }}
+        - name: tcp-leader-election
+          containerPort: {{ .Values.zookeeper.ports.tcp-leaderElection }}
         {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-        - name: client-tls
-          containerPort: {{ .Values.zookeeper.ports.clientTls }}
+        - name: tls-client-tls
+          containerPort: {{ .Values.zookeeper.ports.tls-clientTls }}
         {{- end }}
         env:
         - name: ZOOKEEPER_SERVERS

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -294,10 +294,10 @@ zookeeper:
   restartPodsOnConfigMapChange: false
   ports:
     http: 8000
-    client: 2181
-    clientTls: 2281
-    follower: 2888
-    leaderElection: 3888
+    tcp-client: 2181
+    tls-clientTls: 2281
+    tcp-follower: 2888
+    tcp-leaderElection: 3888
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   probe:
@@ -421,7 +421,7 @@ bookkeeper:
   restartPodsOnConfigMapChange: false
   ports:
     http: 8000
-    bookie: 3181
+    tcp-bookie: 3181
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   probe:
@@ -631,8 +631,8 @@ broker:
   ports:
     http: 8080
     https: 8443
-    pulsar: 6650
-    pulsarssl: 6651
+    tcp-pulsar: 6650
+    tls-pulsarssl: 6651
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   probe:
@@ -810,8 +810,8 @@ proxy:
   ports:
     http: 80
     https: 443
-    pulsar: 6650
-    pulsarssl: 6651
+    tcp-pulsar: 6650
+    tls-pulsarssl: 6651
   service:
     annotations: {}
     type: LoadBalancer


### PR DESCRIPTION
Fixes #152 

### Motivation

Change port naming to abide by Istio protocol rules

### Modifications

Changed port names
- pulsar -> tcp-pulsar
- pulsarssl --> tls-pulsarssl etc

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
