### PR TITLE
Bump Pulsar version to 2.8.1

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -37,6 +37,10 @@ components:
 
 zookeeper:
   replicaCount: 1
+  configData:
+    PULSAR_EXTRA_OPTS: >
+      -Dzookeeper.ssl.hostnameVerification=false
+      -Dzookeeper.ssl.quorum.hostnameVerification=false
 
 bookkeeper:
   replicaCount: 3
@@ -56,6 +60,7 @@ broker:
     managedLedgerDefaultEnsembleSize: "1"
     managedLedgerDefaultWriteQuorum: "1"
     managedLedgerDefaultAckQuorum: "1"
+    functionsWorkerEnabled: "false"
 
 proxy:
   replicaCount: 1
@@ -73,3 +78,13 @@ tls:
 certs:
   internal_issuer:
     enabled: false
+
+images:
+  zookeeper:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent
+  bookie:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -37,6 +37,10 @@ components:
 
 zookeeper:
   replicaCount: 1
+  configData:
+    PULSAR_EXTRA_OPTS: >
+      -Dzookeeper.ssl.hostnameVerification=false
+      -Dzookeeper.ssl.quorum.hostnameVerification=false
 
 bookkeeper:
   replicaCount: 3
@@ -79,3 +83,13 @@ tls:
 certs:
   internal_issuer:
     enabled: false
+
+images:
+  zookeeper:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent
+  bookie:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -37,6 +37,10 @@ components:
 
 zookeeper:
   replicaCount: 1
+  configData:
+    PULSAR_EXTRA_OPTS: >
+      -Dzookeeper.ssl.hostnameVerification=false
+      -Dzookeeper.ssl.quorum.hostnameVerification=false
 
 bookkeeper:
   replicaCount: 3

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -37,6 +37,10 @@ components:
 
 zookeeper:
   replicaCount: 1
+  configData:
+    PULSAR_EXTRA_OPTS: >
+      -Dzookeeper.ssl.hostnameVerification=false
+      -Dzookeeper.ssl.quorum.hostnameVerification=false
 
 bookkeeper:
   replicaCount: 3
@@ -75,3 +79,13 @@ tls:
 certs:
   internal_issuer:
     enabled: false
+
+images:
+  zookeeper:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent
+  bookie:
+    repository: apachepulsar/pulsar-all
+    tag: 2.8.1
+    pullPolicy: IfNotPresent

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: "2.7.2"
+appVersion: "2.8.1"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.2
+version: 2.8.1
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -149,27 +149,27 @@ extra:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2
@@ -283,7 +283,7 @@ zookeeper:
   replicaCount: 3
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   # If using Prometheus-Operator enable this PodMonitor to discover zookeeper scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:
@@ -525,12 +525,7 @@ bookkeeper:
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
       -XX:+PrintGCDetails
-      -XX:+PrintGCTimeStamps
-      -XX:+PrintGCApplicationStoppedTime
-      -XX:+PrintHeapAtGC
       -verbosegc
-      -Xloggc:/var/log/bookie-gc.log
-      -XX:G1LogLevel=finest
     # configure the memory settings based on jvm memory settings
     dbStorage_writeCacheMaxSizeMb: "32"
     dbStorage_readAheadCacheMaxSizeMb: "32"
@@ -600,7 +595,7 @@ pulsar_metadata:
   image:
     # the image used for running `pulsar-cluster-initialize` job
     repository: apachepulsar/pulsar-all
-    tag: 2.7.2
+    tag: 2.8.1
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:


### PR DESCRIPTION
### Motivation
Currently, Pulsar 2.8.1 has been released, we can update the pulsar version in helm chart.

### Modifications
1. Bump Pulsar version to 2.8.1

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
