### PR TITLE
Fix #152 Add Helm chart support for Istio port naming (attempt 2)

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.2
+version: 2.7.3
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -170,7 +170,7 @@ spec:
           readOnlyRootFilesystem: false
       {{- end}}
         ports:
-        - name: bookie
+        - name: "{{ .Values.tcpPrefix }}bookie"
           containerPort: {{ .Values.bookkeeper.ports.bookie }}
         - name: http
           containerPort: {{ .Values.bookkeeper.ports.http }}

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -34,13 +34,13 @@ spec:
   - name: http
     port: {{ .Values.broker.ports.http }}
   {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-  - name: pulsar
+  - name: "{{ .Values.tcpPrefix }}pulsar"
     port: {{ .Values.broker.ports.pulsar }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   - name: https
     port: {{ .Values.broker.ports.https }}
-  - name: pulsarssl
+  - name: "{{ .Values.tlsPrefix }}pulsarssl"
     port: {{ .Values.broker.ports.pulsarssl }}
   {{- end }}
   clusterIP: None

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -212,13 +212,13 @@ spec:
         - name: http
           containerPort: {{ .Values.broker.ports.http }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-        - name: pulsar
+        - name: "{{ .Values.tcpPrefix }}pulsar"
           containerPort: {{ .Values.broker.ports.pulsar }}
         {{- end }}
         {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
         - name: https
           containerPort: {{ .Values.broker.ports.https }}
-        - name: pulsarssl
+        - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.broker.ports.pulsarssl }}
         {{- end }}
         envFrom:

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,7 +37,7 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
-    - name: pulsar
+    - name: "{{ .Values.tcpPrefix }}pulsar"
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
     {{- end }}
@@ -45,7 +45,7 @@ spec:
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
-    - name: pulsarssl
+    - name: "{{ .Values.tlsPrefix }}pulsarssl"
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
     {{- end }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -183,13 +183,13 @@ spec:
         - name: http
           containerPort: {{ .Values.proxy.ports.http }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
-        - name: pulsar
+        - name: "{{ .Values.tcpPrefix }}pulsar"
           containerPort: {{ .Values.proxy.ports.pulsar }}
         {{- end }}
         {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
         - name: https
           containerPort: {{ .Values.proxy.ports.https }}
-        - name: pulsarssl
+        - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.proxy.ports.pulsarssl }}
         {{- end }}
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}

--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -34,14 +34,14 @@ spec:
     # prometheus needs to access /metrics endpoint
     - name: http
       port: {{ .Values.zookeeper.ports.http }}
-    - name: follower
+    - name: "{{ .Values.tcpPrefix }}follower"
       port: {{ .Values.zookeeper.ports.follower }}
-    - name: leader-election
+    - name: "{{ .Values.tcpPrefix }}leader-election"
       port: {{ .Values.zookeeper.ports.leaderElection }}
-    - name: client
+    - name: "{{ .Values.tcpPrefix }}client"
       port: {{ .Values.zookeeper.ports.client }}
     {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-    - name: client-tls
+    - name: "{{ .Values.tlsPrefix }}client-tls"
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -48,6 +48,15 @@ initialize: false
 ## be stored under the provided path
 metadataPrefix: ""
 
+## Port name prefix
+##
+## Used for Istio support which depends on a standard naming of ports
+## See https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
+## Prefixes are disabled by default
+
+tcpPrefix: ""  # For Istio this will be "tcp"
+tlsPrefix: ""  # For Istio this will be "tls"
+
 ## Persistence
 ##
 ## If persistence is enabled, components that have state will

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -54,8 +54,8 @@ metadataPrefix: ""
 ## See https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
 ## Prefixes are disabled by default
 
-tcpPrefix: ""  # For Istio this will be "tcp"
-tlsPrefix: ""  # For Istio this will be "tls"
+tcpPrefix: ""  # For Istio this will be "tcp-"
+tlsPrefix: ""  # For Istio this will be "tls-"
 
 ## Persistence
 ##


### PR DESCRIPTION
Fixes #152 

### Motivation

Support prefix in front of port names to abide by Istio protocol rules
https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

### Modifications

Support adding a prefix
- pulsar -> tcp-pulsar
- pulsarssl --> tls-pulsarssl etc

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

NOTE: @lhotari @sijie this is designed to address feedback in #159 - just easier to create a net new PR