### PR TITLE
useV2WireProtocol for bookkeeper autorecovery

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -597,6 +597,7 @@ autorecovery:
   configData:
     BOOKIE_MEM: >
       -Xms64m -Xmx64m
+    PULSAR_PREFIX_useV2WireProtocol: "true"
 
 ## Pulsar Zookeeper metadata. The metadata will be deployed as
 ## soon as the last zookeeper node is reachable. The deployment


### PR DESCRIPTION
### Motivation
Currently we only set `bookkeeperUseV2WireProtocol=true` on Pulsar brokers to enforce brokers to use v2 protocol to avoid GC issues introduced by protobuf. 

However, we don’t set this setting on autorecovery, and the default value is `false`, Hence AutoRecovery will use v3 protocol.

We'd better set `useV2WireProtocol=true` in autorecovery in the helm charts

### Modifications

Set `useV2WireProtocol=true` in autorecovery.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
