### PR TITLE
Workaround kustomize bug in pulsar cluster init

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.3
+version: 2.7.4
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -86,7 +86,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-          - >
+          - |
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.cluster.name" . }} \


### PR DESCRIPTION
### Motivation

Due to bug in kustomize https://github.com/kubernetes-sigs/kustomize/issues/4201 we cannot deploy pulsar helm chart via fluxcd which uses kustomize as post-renderer (as desribed in https://github.com/fluxcd/flux2/issues/1968). Pulsar cluster initialization fails, because jobs responsible for initialization is missing some arguments due extra newline:
```
$ kubectl -n pulsar get job pulsar-pulsar-init -o yaml | grep initialize-cluster-metadata -B3 -A3
      - args:
        - |2

          bin/pulsar initialize-cluster-metadata \

            --cluster pulsar \
            --zookeeper pulsar-zookeeper:2181 \
```
There are also other places where this bug is hit, but extra generated newline is not significant and does no break anything.

### Modifications

Replace folding block with multiline string to workaround https://github.com/kubernetes-sigs/kustomize/issues/4201



### Verifying this change

- [ ] Make sure that the change passes the CI checks.

1. Prepare kustomization file:
```
cat <<EOT >./kustomization.yaml
resources:
- pulsar-init.yaml
EOT
```
2. Run helm to generate k8s manifests for pulsar init jobs:
```
$ helm template . -s templates/pulsar-cluster-initialize.yaml --set initialize=true > pulsar-init.yaml
```
3. Run kustomize:
```
kustomize build . > pulsar-init-kustomized.yaml
```
4. Check that there is no extra newline in arguments of pulsar cluster initialization job:
```
$ grep initialize-cluster-metadata -B3 -A3 pulsar-init-kustomized.yaml
```