### PR TITLE
when K8S does not support PVC, mount the storage to local disk

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -194,17 +194,17 @@ spec:
       volumes:
       {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
-        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) and(.Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath))}}
+        {{- if and (not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence)) (and .Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath)}}
         hostPath:
-          path: "{{.Values.bookkeeper.volumes.mount_local_disk.journalPath}}/{{ template "pulsar.namespace"}}/bookie/journal"
+          path: {{.Values.bookkeeper.volumes.mount_local_disk.journalPath}}/{{ template "pulsar.namespace" .}}/bookie/journal
           type: DirectoryOrCreate
         {{- else }}
         emptyDir: {}
         {{- end}}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
-        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) and(.Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath))}}
+        {{- if and (not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence)) (and .Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath)}}
         hostPath:
-          path: "{{.Values.bookkeeper.volumes.mount_local_disk.ledgersPath}}/{{ template "pulsar.namespace"}}/bookie/ledgers"
+          path: {{.Values.bookkeeper.volumes.mount_local_disk.ledgersPath}}/{{ template "pulsar.namespace" .}}/bookie/ledgers
           type: DirectoryOrCreate
         {{- else }}
         emptyDir: {}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -194,9 +194,21 @@ spec:
       volumes:
       {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) and(.Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath))}}
+        hostPath:
+          path: "{{.Values.bookkeeper.volumes.mount_local_disk.journalPath}}/{{ template "pulsar.namespace"}}/bookie/journal"
+          type: DirectoryOrCreate
+        {{- else }}
         emptyDir: {}
+        {{- end}}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
+        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.bookkeeper.volumes.persistence) and(.Values.volumes.mount_local_disk.hostPath .Values.bookkeeper.volumes.mount_local_disk.hostPath))}}
+        hostPath:
+          path: "{{.Values.bookkeeper.volumes.mount_local_disk.ledgersPath}}/{{ template "pulsar.namespace"}}/bookie/ledgers"
+          type: DirectoryOrCreate
+        {{- else }}
         emptyDir: {}
+        {{- end}}
       {{- end }}
       {{- include "pulsar.bookkeeper.certs.volumes" . | nindent 6 }}
       {{- include "pulsar.imagePullSecrets" . | nindent 6}}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -189,7 +189,13 @@ spec:
       volumes:
       {{- if not (and (and .Values.volumes.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence) }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
+        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence) and( .Values.volumes.mount_local_disk.hostPath .Values.zookeeper.volumes.mount_local_disk.hostPath)) }}
+        hostPath:
+          path: "{{.Values.zookeeper.volumes.mount_local_disk.path}}/{{ template "pulsar.namespace"}}/zookeeper"
+          type: DirectoryOrCreate
+        {{- else }}
         emptyDir: {}
+        {{- end}}
       {{- end }}
       {{- if .Values.zookeeper.extraVolumes }}
 {{ toYaml .Values.zookeeper.extraVolumes | indent 6 }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -189,9 +189,9 @@ spec:
       volumes:
       {{- if not (and (and .Values.volumes.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence) }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
-        {{- if and(not and(and(.Values.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence) and( .Values.volumes.mount_local_disk.hostPath .Values.zookeeper.volumes.mount_local_disk.hostPath)) }}
+        {{- if and (not (and (and .Values.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence)) (and .Values.volumes.mount_local_disk.hostPath .Values.zookeeper.volumes.mount_local_disk.hostPath) }}
         hostPath:
-          path: "{{.Values.zookeeper.volumes.mount_local_disk.path}}/{{ template "pulsar.namespace"}}/zookeeper"
+          path: {{.Values.zookeeper.volumes.mount_local_disk.path}}/{{ template "pulsar.namespace" .}}/zookeeper
           type: DirectoryOrCreate
         {{- else }}
         emptyDir: {}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -63,6 +63,9 @@ tlsPrefix: ""  # For Istio this will be "tls-"
 ## be deployed with PersistentVolumeClaims, otherwise, for test
 ## purposes, they will be deployed with emptyDir
 ##
+## If you want to mount storage to a local disk, set `persistence`
+## `volumes.persistence` and `volumes.hostPath.emptyDir` to false
+##
 ## This is a global setting that is applied to all components.
 ## If you need to disable persistence for a component,
 ## you can set the `volume.persistence` setting to `false` for
@@ -76,6 +79,10 @@ volumes:
   # configure the components to use local persistent volume
   # the local provisioner should be installed prior to enable local persistent volume
   local_storage: false
+  # If you want to mount to a local disk, set `hostPath` to true
+  # If `hostPath` is disabled, volumes is emptyDir.
+  mount_local_disk:
+    hostPath: false
 
 ## RBAC
 ##
@@ -354,8 +361,14 @@ zookeeper:
   extraVolumes: []
   extraVolumeMounts: []
   volumes:
-    # use a persistent volume or emptyDir
+    # use a persistent volume or hostPath(eg: emptyDir, hostPath)
+    # If you want to set hostPath, set `persistence` to false
     persistence: true
+    # If you want to mount to a local disk, set `hostPath` to true and set the mount path
+    # If `hostPath` is disabled, volumes is emptyDir.
+    mount_local_disk:
+      hostPath: true
+      path: "/data/pulsar"
     data:
       name: data
       size: 20Gi
@@ -476,8 +489,15 @@ bookkeeper:
   extraVolumes: []
   extraVolumeMounts: []
   volumes:
-    # use a persistent volume or emptyDir
+    # use a persistent volume or hostPath(eg: emptyDir, hostPath)
+    # If you want to set hostPath, set `persistence` to false
     persistence: true
+    # If you want to mount to a local disk, set `hostPath` to true and set the mount path
+    # If `hostPath` is disabled, volumes is emptyDir.
+    mount_local_disk:
+      hostPath: true
+      journalPath: "/data/pulsar"
+      ledgersPath: "/data/pulsar"
     journal:
       name: journal
       size: 10Gi


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

Installing ZooKeeper and BookKeeper through Helm Charts fails when K8S does not support PVC, so I think Helm Charts should support mounting to local disks.

### Modifications

* `values.yaml` added the `hostPath` configuration for mounting to a local disk.
* Mount the `/zookeeper/data` directory to the local disk in  `zookeeper-statefulset.yaml` .
* In `bookkeeper-statefulset.yaml`, mount the `/bookie/journal` and `/bookie/ledgers` to the local disk. For example, mount journal to the local SSD and ledgers to HDD.

### Verifying this change

- [ ]  Make sure that the change passes the CI checks.

