### PR TITLE
The Token management function is not supported when pulsar Manager is deployed using helm Charts.

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-configmap.yaml
+++ b/charts/pulsar/templates/pulsar-manager-configmap.yaml
@@ -27,5 +27,10 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
 data:
+  {{- if and (and .Values.auth.authorization.enabled .Values.auth.authentication.enabled) (eq .Values.auth.authentication.provider "jwt")}}
+  JWT_BROKER_TOKEN_MODE: PRIVATE
+  JWT_BROKER_PRIVATE_KEY: "file:///pulsar-manager/keys/token/private.key"
+  JWT_BROKER_PUBLIC_KEY: "file:///pulsar-manager/keys/token/public.key"
+  {{- end}}
 {{ toYaml .Values.pulsar_manager.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -65,6 +65,12 @@ spec:
           volumeMounts:
           - name: pulsar-manager-data
             mountPath: /data
+          - name: token-keys
+            mountPath: /pulsar-manager/keys
+            readOnly: true
+          - name: broker-token
+            mountPath: /pulsar-manager/tokens
+            readOnly: true
           envFrom:
           - configMapRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
@@ -93,5 +99,19 @@ spec:
       volumes:
         - name: pulsar-manager-data
           emptyDir: {}
+        - name: token-keys
+          secret:
+            secretName: "{{ template "pulsar.fullname" .}}-token-asymmetric-key"
+            items:
+              - key: PUBLICKEY
+                path: token/public.key
+              - key: PRIVATEKEY
+                path: token/private.key
+        - name: broker-token
+          secret:
+            secretName: "{{ template "pulsar.fullname" .}}-token-admin"
+            items:
+              - key: TOKEN
+                path: broker/token
 
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1057,7 +1057,7 @@ pulsar_manager:
     URL: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
     LOG_LEVEL: DEBUG
     ## If you enabled authentication support
-    ## JWT_TOKEN: <token>
+    ## BACKEND_JWT_TOKEN: <token>
     ## SECRET_KEY: data:base64,<secret key>
   ## Pulsar manager service
   ## templates/pulsar-manager-service.yaml


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

*In pulsar multi-tenant scenario, Pulsar Manager, as a management tool, provides a Web page for token management, but the helm deployment mode does not support token management.*

### Modifications

* Add token management to Pulsar Manager when deploying pulsar using helm.
* Mount asymmetric encryption Secret into the Pulsar Manager container and add asymmetric encryption related configurations in `pulsar-manager-configmap.yaml`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
