### PR TITLE
Another fix for #158. Bookie Service also needs the prefix on the port name

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.3
+version: 2.7.4
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper-service.yaml
@@ -32,7 +32,7 @@ metadata:
 {{- end }}
 spec:
   ports:
-  - name: bookie
+  - name: "{{ .Values.tcpPrefix }}bookie"
     port: {{ .Values.bookkeeper.ports.bookie }}
   - name: http
     port: {{ .Values.bookkeeper.ports.http }}


### PR DESCRIPTION
Fixes #158 (This is the second PR - see also https://github.com/apache/pulsar-helm-chart/pull/162)

### Motivation

* All non-standard port-names need a proper protocol prefix to support Istio
 https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
 
### Modifications

Add the prefix value before `bookie`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

NOTE: Unclear how testing in several of my environments missed this even though Istio mTLS was turned on etc.
