### PR TITLE
Fixes #173 Support both Role Binding and Cluster Role Binding dependi…

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.4
+version: 2.7.5
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -34,11 +34,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- if .Values.rbac.limit_to_namespace }}
-  kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
-{{- else}}
   kind: Role
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-role"
+{{- else}}
+  kind: ClusterRole
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
 {{- end}}
 subjects:
 - kind: ServiceAccount
@@ -48,13 +48,13 @@ subjects:
 
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.limit_to_namespace }}
-kind: ClusterRole
-metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
-{{- else}}
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-role"
+{{- else}}
+kind: ClusterRole
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
 {{- end}}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -22,17 +22,24 @@
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.limit_to_namespace }}
 kind: RoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-rolebinding"
 {{- else}}
 kind: ClusterRoleBinding
-{{- end}}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrolebinding"
+{{- end}}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.limit_to_namespace }}
   kind: ClusterRole
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
+{{- else}}
+  kind: Role
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-role"
+{{- end}}
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
@@ -40,9 +47,15 @@ subjects:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
 kind: ClusterRole
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
+{{- else}}
+kind: Role
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-role"
+{{- end}}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
…ng on rbac.limit_to_namespace

Fixes #173 

### Motivation
Using `rbac.rbac.limit_to_namespace` allow us to not create a ClusterRole / ClusterRoleBinding if we want multiple helm releases with the same name in different k8s namespaces

### Modifications

Added if/then conditions to the template

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
