### PR TITLE
[Performance] Remove -XX:-ResizePLAB JVM option which degrades performance on JDK11

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -530,7 +530,6 @@ bookkeeper:
       -XX:ConcGCThreads=4
       -XX:G1NewSizePercent=50
       -XX:+DisableExplicitGC
-      -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
       -XX:+PrintGCDetails
@@ -704,7 +703,6 @@ broker:
       -XX:ConcGCThreads=4
       -XX:G1NewSizePercent=50
       -XX:+DisableExplicitGC
-      -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
     managedLedgerDefaultEnsembleSize: "2"
@@ -810,7 +808,6 @@ proxy:
       -XX:ConcGCThreads=4
       -XX:G1NewSizePercent=50
       -XX:+DisableExplicitGC
-      -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
   ## Proxy service


### PR DESCRIPTION
### Motivation

Specifying `-XX:-ResizePLAB` JVM option on JDK 11 degrades performance. 

- see https://bugs.openjdk.java.net/browse/JDK-8257145
  and https://www.programmersought.net/2021/08/09/after-jdk-upgrade-from-8-to-11-the-hbase-performance-drops-by-nearly-20/

### Modifications

- remove `-XX:-ResizePLAB` from default JVM options