### PR TITLE
Make k8s probe timeoutSeconds configurable and fix k8s 1.20+ compatibility

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -135,6 +135,7 @@ spec:
             port: {{ .Values.bookkeeper.ports.http }}
           initialDelaySeconds: {{ .Values.bookkeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.bookkeeper.probe.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.bookkeeper.probe.liveness.timeoutSeconds }}
           failureThreshold: {{ .Values.bookkeeper.probe.liveness.failureThreshold }}
         {{- end }}
         {{- if .Values.bookkeeper.probe.readiness.enabled }}
@@ -144,6 +145,7 @@ spec:
             port: {{ .Values.bookkeeper.ports.http }}
           initialDelaySeconds: {{ .Values.bookkeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.bookkeeper.probe.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.bookkeeper.probe.readiness.timeoutSeconds }}
           failureThreshold: {{ .Values.bookkeeper.probe.readiness.failureThreshold }}
         {{- end }}
         {{- if .Values.bookkeeper.probe.startup.enabled }}
@@ -153,6 +155,7 @@ spec:
             port: {{ .Values.bookkeeper.ports.http }}
           initialDelaySeconds: {{ .Values.bookkeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.bookkeeper.probe.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.bookkeeper.probe.startup.timeoutSeconds }}
           failureThreshold: {{ .Values.bookkeeper.probe.startup.failureThreshold }}
         {{- end }}
       {{- if .Values.bookkeeper.resources }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -168,6 +168,7 @@ spec:
             port: {{ .Values.broker.ports.http }}
           initialDelaySeconds: {{ .Values.broker.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.broker.probe.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.broker.probe.liveness.timeoutSeconds }}
           failureThreshold: {{ .Values.broker.probe.liveness.failureThreshold }}
         {{- end }}
         {{- if .Values.broker.probe.readiness.enabled }}
@@ -177,6 +178,7 @@ spec:
             port: {{ .Values.broker.ports.http }}
           initialDelaySeconds: {{ .Values.broker.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.broker.probe.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.broker.probe.readiness.timeoutSeconds }}
           failureThreshold: {{ .Values.broker.probe.readiness.failureThreshold }}
         {{- end }}
         {{- if .Values.broker.probe.startup.enabled }}
@@ -186,6 +188,7 @@ spec:
             port: {{ .Values.broker.ports.http }}
           initialDelaySeconds: {{ .Values.broker.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.broker.probe.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.broker.probe.startup.timeoutSeconds }}
           failureThreshold: {{ .Values.broker.probe.startup.failureThreshold }}
         {{- end }}
       {{- if .Values.broker.resources }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -148,6 +148,7 @@ spec:
             port: {{ .Values.proxy.ports.http }}
           initialDelaySeconds: {{ .Values.proxy.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.proxy.probe.liveness.timeoutSeconds }}
           failureThreshold: {{ .Values.proxy.probe.liveness.failureThreshold }}
         {{- end }}
         {{- if .Values.proxy.probe.readiness.enabled }}
@@ -157,6 +158,7 @@ spec:
             port: {{ .Values.proxy.ports.http }}
           initialDelaySeconds: {{ .Values.proxy.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.proxy.probe.readiness.timeoutSeconds }}
           failureThreshold: {{ .Values.proxy.probe.readiness.failureThreshold }}
         {{- end }}
         {{- if .Values.proxy.probe.startup.enabled }}
@@ -166,6 +168,7 @@ spec:
             port: {{ .Values.proxy.ports.http }}
           initialDelaySeconds: {{ .Values.proxy.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.proxy.probe.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.proxy.probe.startup.timeoutSeconds }}
           failureThreshold: {{ .Values.proxy.probe.startup.failureThreshold }}
         {{- end }}
       {{- if .Values.proxy.resources }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -149,6 +149,7 @@ spec:
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.zookeeper.probe.readiness.timeoutSeconds }}
           failureThreshold: {{ .Values.zookeeper.probe.readiness.failureThreshold }}
         {{- end }}
         {{- if .Values.zookeeper.probe.liveness.enabled }}
@@ -158,6 +159,7 @@ spec:
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.zookeeper.probe.liveness.timeoutSeconds }}
           failureThreshold: {{ .Values.zookeeper.probe.liveness.failureThreshold }}
         {{- end }}
         {{- if .Values.zookeeper.probe.startup.enabled }}
@@ -167,6 +169,7 @@ spec:
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.startup.periodSeconds }}
+          timeoutSeconds: {{ .Values.zookeeper.probe.startup.timeoutSeconds }}
           failureThreshold: {{ .Values.zookeeper.probe.startup.failureThreshold }}
         {{- end }}
         volumeMounts:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -315,16 +315,19 @@ zookeeper:
       failureThreshold: 10
       initialDelaySeconds: 10
       periodSeconds: 30
+      timeoutSeconds: 5
     readiness:
       enabled: true
       failureThreshold: 10
       initialDelaySeconds: 10
       periodSeconds: 30
+      timeoutSeconds: 5
     startup:
       enabled: false
       failureThreshold: 30
       initialDelaySeconds: 10
       periodSeconds: 30
+      timeoutSeconds: 5
   affinity:
     anti_affinity: true
     # Set the anti affinity type. Valid values:
@@ -439,16 +442,19 @@ bookkeeper:
       failureThreshold: 60
       initialDelaySeconds: 10
       periodSeconds: 30
+      timeoutSeconds: 5
     readiness:
       enabled: true
       failureThreshold: 60
       initialDelaySeconds: 10
       periodSeconds: 30
+      timeoutSeconds: 5
     startup:
       enabled: false
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 30
+      timeoutSeconds: 5
   affinity:
     anti_affinity: true
     # Set the anti affinity type. Valid values:
@@ -650,16 +656,19 @@ broker:
       failureThreshold: 10
       initialDelaySeconds: 30
       periodSeconds: 10
+      timeoutSeconds: 5
     readiness:
       enabled: true
       failureThreshold: 10
       initialDelaySeconds: 30
       periodSeconds: 10
+      timeoutSeconds: 5
     startup:
       enabled: false
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 10
+      timeoutSeconds: 5
   affinity:
     anti_affinity: true
     # Set the anti affinity type. Valid values:
@@ -756,16 +765,19 @@ proxy:
       failureThreshold: 10
       initialDelaySeconds: 30
       periodSeconds: 10
+      timeoutSeconds: 5
     readiness:
       enabled: true
       failureThreshold: 10
       initialDelaySeconds: 30
       periodSeconds: 10
+      timeoutSeconds: 5
     startup:
       enabled: false
       failureThreshold: 30
       initialDelaySeconds: 60
       periodSeconds: 10
+      timeoutSeconds: 5
   affinity:
     anti_affinity: true
     # Set the anti affinity type. Valid values:


### PR DESCRIPTION
### Motivation

- address compatibility with Kubernetes 1.20+. This impacts "bin/pulsar-zookeeper-ruok.sh" exec probe used in ZK.
  "Before Kubernetes 1.20, the field timeoutSeconds was not respected for exec probes: probes continued running indefinitely, even past their configured deadline, until a result was returned."
   https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
- make k8s probe timeoutSeconds configurable

### Modifications

- Add timeoutSeconds to startup, readiness and liveness probes
- Set the default to 5 seconds 