### PR TITLE
Use NIOServerCnxnFactory for Zookeeper to fix NPE issues with Pulsar 2.8.0+

### DIFF
--- a/charts/pulsar/templates/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper-configmap.yaml
@@ -29,12 +29,15 @@ metadata:
     component: {{ .Values.zookeeper.component }}
 data:
   dataDir: /pulsar/data/zookeeper
+  {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+  # enable zookeeper tls
   PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
   serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
-  # enable zookeeper tls
-  {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
   secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
   PULSAR_PREFIX_secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
+  {{- else }}
+  PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NIOServerCnxnFactory
+  serverCnxnFactory: org.apache.zookeeper.server.NIOServerCnxnFactory
   {{- end }}
 {{ toYaml .Values.zookeeper.configData | indent 2 }}
 {{- end }}


### PR DESCRIPTION
### Motivation

Zookeeper fails with NPEs in Pulsar 2.8.0+, problem reported in https://github.com/apache/pulsar/issues/11070.

### Modifications

Follow recommendation in https://github.com/apache/pulsar/issues/11070#issuecomment-936539979
- switch to use NIOServerCnxnFactory when TLS isn't enabled for Zookeeper.