### PR TITLE
Add ability to run extra commands in the initialization jobs e.g. to quit istio sidecars

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.7
+version: 2.7.8
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -69,6 +69,9 @@ spec:
                 {{- end }}
                 bin/bookkeeper shell initnewcluster;
             fi
+            {{- if .Values.istio.enabled }}
+            priorResult=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $priorResult
+            {{- end }}
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}
         securityContext:
           readOnlyRootFilesystem: false

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -69,8 +69,8 @@ spec:
                 {{- end }}
                 bin/bookkeeper shell initnewcluster;
             fi
-            {{- if .Values.istio.enabled }}
-            priorResult=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $priorResult
+            {{- if .Values.extraInitCommand }}
+              {{ .Values.extraInitCommand }}
             {{- end }}
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}
         securityContext:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -101,6 +101,9 @@ spec:
               --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.https }}/ \
               --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsar }}/ \
               --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsarssl }}/ || true;
+            {{- if .Values.istio.enabled }}
+            priorResult=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $priorResult
+            {{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -101,8 +101,8 @@ spec:
               --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.https }}/ \
               --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsar }}/ \
               --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsarssl }}/ || true;
-            {{- if .Values.istio.enabled }}
-            priorResult=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $priorResult
+            {{- if .Values.extraInitCommand }}
+              {{ .Values.extraInitCommand }}
             {{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -627,8 +627,8 @@ pulsar_metadata:
   #
   # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
 
-istio:
-  enabled: false
+# Can be used to run extra commands in the initialization jobs e.g. to quit istio sidecars etc.
+extraInitCommand: ""
 
 ## Pulsar: Broker cluster
 ## templates/broker-statefulset.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -627,6 +627,9 @@ pulsar_metadata:
   #
   # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
 
+istio:
+  enabled: false
+
 ## Pulsar: Broker cluster
 ## templates/broker-statefulset.yaml
 ##


### PR DESCRIPTION
### Motivation

When using Istio sidecars they keep running even when a Kubernetes job has completed.
For example
```
$ kubectl get pods | grep pulsar | grep init
platform-pulsar-bookkeeper-init-vwp6v                             1/2     NotReady    0          13d
platform-pulsar-pulsar-init-c2c72                                 1/2     NotReady    0          13d
```

### Modifications

* Added a new Helm chart value `extraInitContainer` (default: "")
* This command can be used to send a quit call to Istio sidecars e.g.
```
  values:
    extraInitCommand: "curl -vvv -fsI -X POST http://localhost:15020/quitquitquit"
```
* See https://medium.com/redbox-techblog/handling-istio-sidecars-in-kubernetes-jobs-c392661c4af7 for more information including alternatives

### Local Testing 
Tested in Minikube where Istio is NOT running with
```
  values:
    extraInitCommand: "curl -vvv -fsI -X POST http://localhost:15020/quitquitquit"
```
and saw the following
```
15:55:22.416 [main-EventThread] INFO  org.apache.zookeeper.ClientCnxn - EventThread shut down for session: 0x100019308350014
15:55:22.416 [main] INFO  org.apache.zookeeper.ZooKeeper - Session: 0x100019308350014 closed
*   Trying 127.0.0.1:15020...
* connect to 127.0.0.1 port 15020 failed: Connection refused
*   Trying ::1:15020...
* Immediate connect fail for ::1: Cannot assign requested address
* Failed to connect to localhost port 15020: Connection refused
* Closing connection 0
```

also tested without the setting and the jobs started up fine with nothing new or unusual in the log files

```
$ kubectl get pods | grep pulsar
pulsar-bookkeeper-0                              1/1     Running     0          2m44s
pulsar-bookkeeper-init-b4r4w                     0/1     Completed   0          2m44s
pulsar-broker-0                                  1/1     Running     0          2m44s
pulsar-proxy-0                                   1/1     Running     0          2m44s
pulsar-pulsar-init-7zvc2                         0/1     Completed   0          2m44s
pulsar-zookeeper-0                               1/1     Running     0          2m44s
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
