### PR TITLE
Fixes #177 Fix indentation of component, as it should be under the la…

### DIFF
--- a/charts/pulsar/templates/dashboard-ingress.yaml
+++ b/charts/pulsar/templates/dashboard-ingress.yaml
@@ -24,7 +24,7 @@ kind: Ingress
 metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
-  component: {{ .Values.dashboard.component }}
+    component: {{ .Values.dashboard.component }}
   annotations:
 {{- with .Values.dashboard.ingress.annotations }}
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
Fixes #177

### Motivation

When deploying the pulsar helm chart, if i open the dashboard indicator, it'll be failed, and show message say the component is unknown field. Reason is the indentation of component line, it should be the child level of label tag.

### Modifications

Changed indentation of the component line.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
