### PR TITLE
Update ingress api version, extension/v1beta1 will not be supported i…

### DIFF
--- a/charts/pulsar/templates/dashboard-ingress.yaml
+++ b/charts/pulsar/templates/dashboard-ingress.yaml
@@ -19,7 +19,11 @@
 
 {{- if .Values.extra.dashboard }}
 {{- if .Values.dashboard.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   labels:
@@ -45,8 +49,17 @@ spec:
       http:
         paths:
           - path: {{ .Values.dashboard.ingress.path }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
               servicePort: {{ .Values.dashboard.ingress.port }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
+                port:
+                  number: {{ .Values.dashboard.ingress.port }}
+            {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/dashboard-ingress.yaml
+++ b/charts/pulsar/templates/dashboard-ingress.yaml
@@ -19,7 +19,7 @@
 
 {{- if .Values.extra.dashboard }}
 {{- if .Values.dashboard.ingress.enabled }}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
@@ -49,7 +49,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.dashboard.ingress.path }}
-            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
               servicePort: {{ .Values.dashboard.ingress.port }}

--- a/charts/pulsar/templates/grafana-ingress.yaml
+++ b/charts/pulsar/templates/grafana-ingress.yaml
@@ -19,7 +19,11 @@
 
 {{- if or .Values.monitoring.grafana .Values.extra.monitoring }}
 {{- if .Values.grafana.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
@@ -42,9 +46,18 @@ spec:
     - http:
         paths:
         - path: {{ .Values.grafana.ingress.path }}
+          {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
           backend:
             serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
             servicePort: {{ .Values.grafana.ingress.port }}
+          {{- else }}
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
+              port:
+                number: {{ .Values.grafana.ingress.port }}
+          {{- end }}
       {{- if .Values.grafana.ingress.hostname }}
       host: {{ .Values.grafana.ingress.hostname }}
       {{- end }}

--- a/charts/pulsar/templates/grafana-ingress.yaml
+++ b/charts/pulsar/templates/grafana-ingress.yaml
@@ -19,7 +19,7 @@
 
 {{- if or .Values.monitoring.grafana .Values.extra.monitoring }}
 {{- if .Values.grafana.ingress.enabled }}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
@@ -46,7 +46,7 @@ spec:
     - http:
         paths:
         - path: {{ .Values.grafana.ingress.path }}
-          {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
           backend:
             serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
             servicePort: {{ .Values.grafana.ingress.port }}

--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -18,7 +18,11 @@
 #
 
 {{- if .Values.proxy.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   labels:
@@ -43,6 +47,7 @@ spec:
     - http:
         paths:
           - path: {{ .Values.proxy.ingress.path }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
               {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
@@ -50,6 +55,18 @@ spec:
               {{- else }}
               servicePort: {{ .Values.proxy.ports.http }}
               {{- end }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+                port:
+                  {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
+                  number: {{ .Values.proxy.ports.https }}
+                  {{- else }}
+                  number: {{ .Values.proxy.ports.http }}
+                  {{- end }}
+            {{- end }}
       {{- if .Values.proxy.ingress.hostname }}
       host: {{ .Values.proxy.ingress.hostname }}
       {{- end }}

--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.proxy.ingress.enabled }}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
@@ -47,7 +47,7 @@ spec:
     - http:
         paths:
           - path: {{ .Values.proxy.ingress.path }}
-            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
               {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -18,7 +18,11 @@
 #
 
 {{- if .Values.pulsar_manager.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   labels:
@@ -43,9 +47,18 @@ spec:
     - http:
         paths:
           - path: {{ .Values.pulsar_manager.ingress.path }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.service.targetPort }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
+                port:
+                  number: {{ .Values.pulsar_manager.service.targetPort }}
+            {{- end }}
       {{- if .Values.pulsar_manager.ingress.hostname }}
       host: {{ .Values.pulsar_manager.ingress.hostname }}
       {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.pulsar_manager.ingress.enabled }}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
@@ -47,7 +47,7 @@ spec:
     - http:
         paths:
           - path: {{ .Values.pulsar_manager.ingress.path }}
-            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.service.targetPort }}


### PR DESCRIPTION
…n new k8s version, this change keep backward compatibility for lower kubernetes version 

Fixes #157

### Motivation

The ingress api extensions/v1beta1 version will not be supported in k8s version 1.22+, need to update to new networking.k8s.io/v1.
This PR also keep support for old k8s version, to provide enough compatibility.

### Modifications

Updated the api version for below 4 components:
1. dashboard-ingress
2. grafana-ingress
3. proxy-ingress
4. pulsar-manager-ingress

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
