### PR TITLE
[Security] Workaround for CVE-2021-44228 Log4J RCE when Log4J >= 2.10.0

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.5
+version: 2.7.6
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -139,7 +139,7 @@ spec:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.autorecovery.zookeeper.tls.settings" . | nindent 10 }}
-          exec bin/bookkeeper autorecovery
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/bookkeeper autorecovery
         ports:
         - name: http
           containerPort: {{ .Values.autorecovery.ports.http }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -167,7 +167,7 @@ spec:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
-          exec bin/pulsar bookie;
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}
         securityContext:
           readOnlyRootFilesystem: false

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -209,7 +209,7 @@ spec:
             bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} get {{ template "pulsar.broker.znode" . }};
           done;
           cat conf/pulsar_env.sh;
-          exec bin/pulsar broker;
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar broker;
         ports:
         # prometheus needs to access /metrics endpoint
         - name: http

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -180,7 +180,7 @@ spec:
         - >
           bin/apply-config-from-env.py conf/proxy.conf &&
           echo "OK" > status &&
-          exec bin/pulsar proxy
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
         # prometheus needs to access /metrics endpoint
         - name: http

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
           bin/apply-config-from-env.py conf/zookeeper.conf;
           {{- include "pulsar.zookeeper.tls.settings" . | nindent 10 }}
           bin/generate-zookeeper-config.sh conf/zookeeper.conf;
-          exec bin/pulsar zookeeper;
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar zookeeper;
         ports:
         # prometheus needs to access /metrics endpoint
         - name: http


### PR DESCRIPTION
### Motivation

CVE-2021-44228 , a severe RCE for Log4J.

The workaround is to set `-Dlog4j2.formatMsgNoLookups=true` system property. This workaround applies for Log4J >= 2.10.0 . This covers all vulnerable Pulsar versions since Log4J2 version was 2.10.0 when the dependency was introduced to Pulsar in https://github.com/apache/pulsar/pull/680 .


### Modifications

Add `OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true"` prefix to calls to `exec bin/pulsar` and `exec bin/bookkeeper` . This results in `-Dlog4j2.formatMsgNoLookups=true` system property getting set.