### PR TITLE
Add LOG4J_FORMAT_MSG_NO_LOOKUPS=true as mitigation for Pulsar Functions process runtime

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -117,6 +117,9 @@ spec:
         args:
         - >
           {{- include "pulsar.autorecovery.init.verify_cluster_id" . | nindent 10 }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
@@ -143,6 +146,9 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.autorecovery.ports.http }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -73,6 +73,9 @@ spec:
         securityContext:
           readOnlyRootFilesystem: false
       {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -115,6 +115,9 @@ spec:
         # only reformat bookie if bookkeeper is running without persistence
         - >
           {{- include "pulsar.bookkeeper.init.verify_cluster_id" . | nindent 10 }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
@@ -177,6 +180,9 @@ spec:
           containerPort: {{ .Values.bookkeeper.ports.bookie }}
         - name: http
           containerPort: {{ .Values.bookkeeper.ports.http }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -148,6 +148,9 @@ spec:
               bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }} | grep Name | wc -l)";
             done;
             echo "bookkeeper cluster is ready";
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
           - configMapRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
@@ -224,6 +227,9 @@ spec:
         - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.broker.ports.pulsarssl }}
         {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/dashboard-deployment.yaml
+++ b/charts/pulsar/templates/dashboard-deployment.yaml
@@ -65,4 +65,6 @@ spec:
         env:
         - name: SERVICE_URL
           value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
 {{- end }}

--- a/charts/pulsar/templates/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana-deployment.yaml
@@ -69,6 +69,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"        
         # for supporting apachepulsar/pulsar-grafana
         - name: PROMETHEUS_URL
           value: http://{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}:9090/

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -199,6 +199,9 @@ spec:
         securityContext:
           readOnlyRootFilesystem: false
       {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -71,6 +71,9 @@ spec:
           until bin/bookkeeper shell whatisinstanceid; do
             sleep 3;
           done;
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -69,6 +69,8 @@ spec:
           - configMapRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"          
           - name: PULSAR_CLUSTER
             value: {{ template "pulsar.fullname" . }}
           - name: USERNAME

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -78,6 +78,9 @@ spec:
         securityContext:
           readOnlyRootFilesystem: false
       {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -135,6 +135,8 @@ spec:
           value:
             {{- $global := . }}
             {{ range $i, $e := until (.Values.zookeeper.replicaCount | int) }}{{ if ne $i 0 }},{{ end }}{{ template "pulsar.fullname" $global }}-{{ $global.Values.zookeeper.component }}-{{ printf "%d" $i }}{{ end }}
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"


### PR DESCRIPTION
### Motivation

- required for disabling the CVE-2021-44228 vulnerable feature in Log4J 2.x in Pulsar Functions when using the process runtime.

### Additional context

- please notice that for mitigating the k8s runtime for Pulsar Functions, it's necessary
  to patch the used docker image, more information in
  https://github.com/lhotari/pulsar-docker-images-patch-CVE-2021-44228
  pulsarDockerImageName setting should point to the patched image

- https://twitter.com/brunoborges/status/1469462412679991300 contains information about the LOG4J_FORMAT_MSG_NO_LOOKUPS=true workaround.

### Modifications

Add LOG4J_FORMAT_MSG_NO_LOOKUPS=true environment variable workaround to all possible locations as an additional mitigation which also covers forked Java processes.