### PR TITLE
added arm64 in common_auth.sh

### DIFF
--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -25,7 +25,7 @@ fi
 
 OUTPUT=${CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v0.4.0
+PULSARCTL_VERSION=v2.8.2.1
 PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
 export PATH=${HOME}/.pulsarctl/plugins:${PATH}
 
@@ -36,6 +36,7 @@ discoverArch() {
     x86_64) ARCH="amd64";;
     i686) ARCH="386";;
     i386) ARCH="386";;
+    arm64) ARCH="arm64";;
   esac
 }
 


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

Helm chart failed to detect mac m1/arm64 ARCH and failed to install pulsarctl from streamnative. 
pulsarctl version 0.4.0 (The default in the script) has no arm64 binary.

### Modifications

scripts/pulsar/common_auth.sh has been modified by adding arm64 in the ARCH case and bumping up pulsarctl version.
The common_auth.sh downloads the "install.sh" from streamnative" and the install.sh has no arm64 supported neither. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
