### PR TITLE
[CI] Upgrade k8s to 1.18 and also upgrade helm, kind & chart releaser versions

### DIFF
--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -32,9 +32,6 @@ source ${PULSAR_HOME}/.ci/helm.sh
 # create cluster
 ci::create_cluster
 
-# install storage provisioner
-ci::install_storage_provisioner
-
 extra_opts=""
 if [[ "x${SYMMETRIC}" == "xtrue" ]]; then
     extra_opts="-s"

--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-broker-tls.yaml
+++ b/.ci/clusters/values-broker-tls.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-function.yaml
+++ b/.ci/clusters/values-function.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-jwt-asymmetric.yaml
+++ b/.ci/clusters/values-jwt-asymmetric.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-jwt-symmetric.yaml
+++ b/.ci/clusters/values-jwt-symmetric.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-local-pv.yaml
+++ b/.ci/clusters/values-local-pv.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -23,8 +23,6 @@ monitoring:
   node_exporter: false
   alert_manager: false
 
-volumes:
-  local_storage: true
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -28,6 +28,7 @@ KUBECTL=${OUTPUT_BIN}/kubectl
 NAMESPACE=pulsar
 CLUSTER=pulsar-ci
 CLUSTER_ID=$(uuidgen)
+export PATH="$OUTPUT_BIN:$PATH"
 
 # brew package 'coreutils' is required on MacOSX
 # coreutils includes the 'timeout' command
@@ -61,21 +62,6 @@ function ci::delete_cluster() {
     echo "Deleting a kind cluster ..."
     kind delete cluster --name=pulsar-ci-${CLUSTER_ID}
     echo "Successfully delete a kind cluster."
-}
-
-function ci::install_storage_provisioner() {
-    echo "Installing the local storage provisioner ..."
-    ${HELM} repo add streamnative https://charts.streamnative.io
-    ${HELM} repo update
-    ${HELM} install local-storage-provisioner streamnative/local-storage-provisioner
-    WC=$(${KUBECTL} get pods --field-selector=status.phase=Running | grep local-storage-provisioner | wc -l)
-    while [[ ${WC} -lt 1 ]]; do
-      echo ${WC};
-      sleep 15
-      ${KUBECTL} get pods --field-selector=status.phase=Running
-      WC=$(${KUBECTL} get pods --field-selector=status.phase=Running | grep local-storage-provisioner | wc -l)
-    done
-    echo "Successfully installed the local storage provisioner."
 }
 
 function ci::install_cert_manager() {

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ charts/**/*.lock
 
 PRIVATEKEY
 PUBLICKEY
+.vagrant/
+pulsarctl-amd64-linux.tar.gz
+pulsarctl-amd64-linux/

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ charts/**/*.lock
 PRIVATEKEY
 PUBLICKEY
 .vagrant/
-pulsarctl-amd64-linux.tar.gz
-pulsarctl-amd64-linux/
+pulsarctl-*-*.tar.gz
+pulsarctl-*-*/

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ It includes support for:
 
 In order to use this chart to deploy Apache Pulsar on Kubernetes, the followings are required.
 
-1. kubectl 1.14 or higher, compatible with your cluster ([+/- 1 minor release from your cluster](https://kubernetes.io/docs/tasks/tools/install-kubectl/#before-you-begin))
+1. kubectl 1.18 or higher, compatible with your cluster ([+/- 1 minor release from your cluster](https://kubernetes.io/docs/tasks/tools/install-kubectl/#before-you-begin))
 2. Helm v3 (3.0.2 or higher)
-3. A Kubernetes cluster, version 1.14 or higher.
+3. A Kubernetes cluster, version 1.18 or higher.
 
 ## Environment setup
 
@@ -100,7 +100,7 @@ helm install <release-name> apache/pulsar
 
 ## Kubernetes cluster preparation
 
-You need a Kubernetes cluster whose version is 1.14 or higher in order to use this chart, due to the usage of certain Kubernetes features.
+You need a Kubernetes cluster whose version is 1.18 or higher in order to use this chart, due to the usage of certain Kubernetes features.
 
 We provide some instructions to guide you through the preparation: http://pulsar.apache.org/docs/en/helm-prepare/
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# vagrant configuration file for setting up local environment for Pulsar Helm Chart 
+# CI script development.
+#
+# usage: 
+# Starting vagrant box:
+#   vagrant up
+# Connecting to vagrant box and running a ci script:
+#   vagrant ssh
+#   byobu
+#   cd /vagrant
+#   .ci/chart_test.sh .ci/clusters/values-local-pv.yaml
+# Shutting down vagrant box:
+#   vagrant halt
+# Destroying vagrant box:
+#   vagrant destroy
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "7168"
+    vb.cpus = 2
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get update
+    sudo apt-get -y install docker.io
+    sudo adduser vagrant docker
+    echo 'PATH="/vagrant/output/bin:$PATH"' >> /home/vagrant/.profile
+  SHELL
+end

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -25,14 +25,15 @@ fi
 
 OUTPUT=${PULSAR_CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-KUBECTL_VERSION=1.14.3
+KUBECTL_VERSION=1.18.20
 KUBECTL_BIN=$OUTPUT_BIN/kubectl
 HELM_BIN=$OUTPUT_BIN/helm
-HELM_VERSION=3.0.1
-KIND_VERSION=0.6.1
+HELM_VERSION=3.7.2
+KIND_VERSION=0.11.1
 KIND_BIN=$OUTPUT_BIN/kind
 CR_BIN=$OUTPUT_BIN/cr
-CR_VERSION=1.0.0-beta.1
+CR_VERSION=1.3.0
+export PATH="$OUTPUT_BIN:$PATH"
 
 test -d "$OUTPUT_BIN" || mkdir -p "$OUTPUT_BIN"
 
@@ -65,7 +66,7 @@ function hack::ensure_kubectl() {
     echo "Installing kubectl v$KUBECTL_VERSION..."
     tmpfile=$(mktemp)
     trap "test -f $tmpfile && rm $tmpfile" RETURN
-    curl --retry 10 -L -o $tmpfile https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl
+    curl --retry 10 -L -o $tmpfile https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl
     mv $tmpfile $KUBECTL_BIN
     chmod +x $KUBECTL_BIN
 }

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -25,6 +25,7 @@ source ${PULSAR_CHART_HOME}/hack/common.sh
 
 hack::ensure_kubectl
 hack::ensure_helm
+hack::ensure_kind
 
 usage() {
     cat <<EOF
@@ -82,7 +83,7 @@ done
 
 clusterName=${clusterName:-pulsar-dev}
 nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.14.10}
+k8sVersion=${k8sVersion:-v1.18.19}
 volumeNum=${volumeNum:-9}
 
 echo "clusterName: ${clusterName}"
@@ -228,13 +229,6 @@ spec:
           - tcp-connect:${registryNodeIP}:5000
 EOF
 $KUBECTL_BIN apply -f ${registryFile}
-
-echo "init pulsar  env"
-$KUBECTL_BIN apply -f ${PULSAR_CHART_HOME}/manifests/local-dind/local-volume-provisioner.yaml
-
-docker pull gcr.io/google-containers/kube-scheduler:${k8sVersion}
-docker tag gcr.io/google-containers/kube-scheduler:${k8sVersion} mirantis/hypokube:final
-kind load docker-image --name=${clusterName} mirantis/hypokube:final
 
 echo "############# success create cluster:[${clusterName}] #############"
 

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -21,11 +21,11 @@
 
 NAMESPACE=cert-manager
 NAME=cert-manager
-VERSION=v0.13.0
+VERSION=v1.1.0
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/${VERSION}/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${VERSION}/cert-manager.crds.yaml
 
 # Create the namespace 
 kubectl get ns ${NAMESPACE}


### PR DESCRIPTION
### Motivation

Currently k8s 1.14 version is used in CI to verify the Helm chart changes. 

k8s 1.14 became end-of-life [2019-12-11 , over 2 years ago](https://kubernetes.io/releases/patch-releases/#non-active-branch-history).

k8s 1.18 has also reached end-of-life on 2021-06-18 . The upgrade from 1.18 to a newer version can happen in another PR.
 
### Modifications

- upgrade k8s kubectl to v1.18.20
- upgrade kindest/node to v1.18.19 (newest 1.18 for kind)
- upgrade kind to v0.11.1
- upgrade helm to 3.7.2
- upgrade chart releaser to 1.3.0
- upgrade chart apiVersion to v2
- remove usage of streamnative/local-storage-provisioner since it's not needed. kind comes with https://github.com/rancher/local-path-provisioner

- add Vagrantfile for local CI script development [within a Vagrant VM](https://www.vagrantup.com/) 
- add better logging to CI scripts