### PR TITLE
[CI] Add job 45min timeout and cancel duplicate jobs

### DIFF
--- a/.github/workflows/cancel-duplicate-workflows.yml
+++ b/.github/workflows/cancel-duplicate-workflows.yml
@@ -1,0 +1,118 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Cancel duplicate workflows
+on:
+  workflow_run:
+    # this could be any workflow that is always executed by PUSH/PR operation
+    workflows: ["Precommit Style Check"]
+    types: ['requested']
+
+jobs:
+
+  cancel-workflow-runs:
+    runs-on: ubuntu-20.04
+    steps:
+      # the potiuk/cancel-workflow-run action has been allow-listed by
+      # the Apache Infrastructure
+      - name: cancel duplicate lint.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: lint.yml
+      - name: cancel duplicate pulsar_bk_tls.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_bk_tls.yml
+      - name: cancel duplicate pulsar_broker_tls.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_broker_tls.yml
+      - name: cancel duplicate pulsar_function.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_function.yml
+      - name: cancel duplicate pulsar_image.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_image.yml
+      - name: cancel duplicate pulsar_jwt_asymmetric.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_jwt_asymmetric.yml
+      - name: cancel duplicate pulsar_jwt_symmetric.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_jwt_symmetric.yml
+      - name: cancel duplicate pulsar_tls.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_tls.yml
+      - name: cancel duplicate pulsar.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar.yml
+      - name: cancel duplicate pulsar_zkbk_tls.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_zkbk_tls.yml
+      - name: cancel duplicate pulsar_zk_tls.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: pulsar_zk_tls.yml
+      - name: cancel duplicate release.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: release.yml
+      - name: cancel duplicate style.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: style.yml
+      - name: cancel duplicate verify_release.yml
+        uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          cancelMode: allDuplicates
+          workflowFileName: verify_release.yml
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - '.ci/ct.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar.yml
+++ b/.github/workflows/pulsar.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_bk_tls.yml
+++ b/.github/workflows/pulsar_bk_tls.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_broker_tls.yml
+++ b/.github/workflows/pulsar_broker_tls.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_function.yml
+++ b/.github/workflows/pulsar_function.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_image.yml
+++ b/.github/workflows/pulsar_image.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_jwt_asymmetric.yml
+++ b/.github/workflows/pulsar_jwt_asymmetric.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_jwt_symmetric.yml
+++ b/.github/workflows/pulsar_jwt_symmetric.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_tls.yml
+++ b/.github/workflows/pulsar_tls.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_zk_tls.yml
+++ b/.github/workflows/pulsar_zk_tls.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pulsar_zkbk_tls.yml
+++ b/.github/workflows/pulsar_zkbk_tls.yml
@@ -24,10 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
-      - 'hack/kind-cluster-build.sh'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
 
     - name: Set up Go 1.12

--- a/.github/workflows/verify_release.yml
+++ b/.github/workflows/verify_release.yml
@@ -24,9 +24,12 @@ on:
       - '*'
     paths:
       - 'charts/pulsar/**'
+      - '.ci/**'
+      - 'hack/**'
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Motivation

- CI jobs timeout after several hours and this wastes CI resources
- When making multiple changes to a PR job, the previous jobs keep on running. This wastes CI resources.

### Modifications

- add 45 minute timeout for CI jobs
- cancel duplicate jobs