### PR TITLE
Added -Dlog4j2.formatMsgNoLookups=true to PULSAR_MANAGER_OPTS

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.8
+version: 2.7.9
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -89,6 +89,8 @@ spec:
                 {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
                 {{- end }}
+          - name: PULSAR_MANAGER_OPTS
+            value: "$(PULSAR_MANAGER_OPTS) -Dlog4j2.formatMsgNoLookups=true"
         {{- include "pulsar.imagePullSecrets" . | nindent 6}}
       volumes:
         - name: pulsar-manager-data


### PR DESCRIPTION
Fixes #197 

### Motivation

Adds the -Dlog4j2.formatMsgNoLookups=true switch to the pulsar manager commandline. Necessary for pulsar manager v0.1.0, which includes
a dependency on log4j2 2.10.0

### Modifications

Updated the pulsar manager deployment template to update the PULSAR_MANAGER_OPTS environment variable (supported by the pulsar manager startup script) to include -Dlog4j2.formatMsgNoLookups=true.

### Verifying this change

**case 1**: -Dlog4j2.formatMsgNoLookups=true is included when PULSAR_MANAGER_OPTS has not been set in values.yaml:
Install Pulsar via helm chart, making sure that the pulsar manager component is enabled:
```
helm install -n pulsar --set initialize=true pulsar pulsar-2.7.9.tgz
```
Exec into the pulsar manager pod and check that the Java process arguments include "-Dlog4j2.formatMsgNoLookups=true"

**case 2**: -Dlog4j2.formatMsgNoLookups=true is appended to PULSAR_MANAGER_OPTS when PULSAR_MANAGER_OPTS is set in values.yaml:
Install Pulsar via helm chart, setting a value for PULSAR_MANAGER_OPTS:
```
helm install -n pulsar --set initialize=true --set "pulsar_manager.configData.PULSAR_MANAGER_OPTS=-DmyTestOption=whatever" pulsar pulsar-2.7.9.tgz
```
Exec into the pulsar manager pod and check that the Java process arguments include "-DmyTestOption=whatever" and "-Dlog4j2.formatMsgNoLookups=true"
