### PR TITLE
Fix chart releaser command which uses docker image

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -34,7 +34,7 @@ source ${CHARTS_HOME}/hack/common.sh
 source ${CHARTS_HOME}/.ci/git.sh
 
 # allow overwriting cr binary
-CR="docker run -v ${CHARTS_HOME}:/cr quay.io/helmpack/chart-releaser:v${CR_VERSION} cr"
+CR="docker run -v ${CHARTS_HOME}:/cr quay.io/helmpack/chart-releaser:v${CR_VERSION}"
 
 function release::ensure_dir() {
     local dir=$1


### PR DESCRIPTION
### Motivation

- chart releaser command broker after upgrading to 1.3.0 version by #192
- [example failure](https://github.com/apache/pulsar-helm-chart/runs/4785990468?check_suite_focus=true#step:6:28): 
```
Error: unknown command "cr" for "cr"
Run 'cr --help' for usage.
```

### Modifications

- remove `cr` from command since it's part of the docker entrypoint for the `quay.io/helmpack/chart-releaser:v1.3.0` image.
  - `quay.io/helmpack/chart-releaser:v1.0.0-beta.1` image didn't have `cr` as the entrypoint