### PR TITLE
Increase default initialDelaySeconds for Zookeeper probes to workaround ZOOKEEPER-3988

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -313,19 +313,19 @@ zookeeper:
     liveness:
       enabled: true
       failureThreshold: 10
-      initialDelaySeconds: 10
+      initialDelaySeconds: 20
       periodSeconds: 30
       timeoutSeconds: 5
     readiness:
       enabled: true
       failureThreshold: 10
-      initialDelaySeconds: 10
+      initialDelaySeconds: 20
       periodSeconds: 30
       timeoutSeconds: 5
     startup:
       enabled: false
       failureThreshold: 30
-      initialDelaySeconds: 10
+      initialDelaySeconds: 20
       periodSeconds: 30
       timeoutSeconds: 5
   affinity:


### PR DESCRIPTION
### Motivation

- When TLS is enabled for Zookeeper, NettyServerCnxnFactory will be used.
  It contains the issue https://github.com/apache/pulsar/issues/11070 /
  https://issues.apache.org/jira/browse/ZOOKEEPER-3988

### Modification

  - as a workaround, increase the initialDelaySeconds from 10 to 20 to
    reduce the likelyhood of ZOOKEEPER-3988