### PR TITLE
Change default podManagementPolicy to Parallel for Zookeeper

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -292,7 +292,7 @@ zookeeper:
   replicaCount: 3
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   # If using Prometheus-Operator enable this PodMonitor to discover zookeeper scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:


### PR DESCRIPTION
### Motivation

- For speeding up startup, podManagementPolicy should be set to `Parallel` for Zookeeper

### Modifications

- set `zookeeper.podManagementPolicy` to `Parallel` in the default `values.yaml` file.