### PR TITLE
Upgrade cert-manager to 1.5.4

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -266,7 +266,7 @@ auth:
 ## for components within a Pulsar cluster
 certs:
   internal_issuer:
-    apiVersion: cert-manager.io/v1alpha2
+    apiVersion: cert-manager.io/v1
     enabled: false
     component: internal-cert-issuer
     type: selfsigning

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -21,7 +21,7 @@
 
 NAMESPACE=cert-manager
 NAME=cert-manager
-VERSION=v1.1.0
+VERSION=v1.5.4
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."


### PR DESCRIPTION
### Motivation

- Keep cert-manager version updated

### Modifications

- upgrade cert-manager to 1.5.4 version
- use apiVersion `cert-manager.io/v1`