### PR TITLE
Upgrade default images for Grafana & Pulsar Manager

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -190,11 +190,11 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.10
+    tag: 0.0.16
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager
-    tag: v0.1.0
+    tag: v0.2.0
     pullPolicy: IfNotPresent
     hasCommand: false
 


### PR DESCRIPTION
- Grafana Dashboard image from v0.0.10 to v0.0.16
  - changes:
    https://github.com/streamnative/apache-pulsar-grafana-dashboard/compare/d50e2758...v0.0.16

- Pulsar Manager from v0.1.0 to v0.2.0
  - changes:
    https://github.com/apache/pulsar-manager/compare/v0.1.0...v0.2.0