### PR TITLE
Add -XX:+ExitOnOutOfMemoryError to Zookeeper's PULSAR_GC parameters

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -394,6 +394,7 @@ zookeeper:
       -XX:+UnlockExperimentalVMOptions
       -XX:+DoEscapeAnalysis
       -XX:+DisableExplicitGC
+      -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
   ## Add a custom command to the start up process of the zookeeper pods (e.g. update-ca-certificates, jvm commands, etc)
   additionalCommand:


### PR DESCRIPTION
### Motivation

- `-XX:+ExitOnOutOfMemoryError` is used for other components
- it's better to exit the process when an OOME happens since an OOME can leave Zookeeper in a bad state

### Modifications

- Add `-XX:+ExitOnOutOfMemoryError` to Zookeeper's `PULSAR_GC` parameters in the default values.yaml file
