### PR TITLE
Fix setting pulsar manager credentials and disable pulsar manager by default

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
+++ b/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if and (or .Values.components.pulsar_manager .Values.extra.pulsar_manager) (not .Values.pulsar_manager.existingSecretName) }}
+{{- if and (or .Values.components.pulsar_manager .Values.extra.pulsar_manager) (not .Values.pulsar_manager.existingSecretName) (not .Values.pulsar_manager.userManagement.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -71,7 +71,10 @@ spec:
           env:
           - name: PULSAR_CLUSTER
             value: {{ template "pulsar.fullname" . }}
-          - name: USERNAME
+          {{- if not .Values.pulsar_manager.userManagement.enabled }}
+          - name: USER_MANAGEMENT_ENABLE
+            value: false
+          - name: PULSAR_MANAGER_ACCOUNT
             valueFrom:
               secretKeyRef:
                 key: PULSAR_MANAGER_ADMIN_USER
@@ -80,7 +83,7 @@ spec:
                 {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
                 {{- end }}
-          - name: PASSWORD
+          - name: PULSAR_MANAGER_PASSWORD
             valueFrom:
               secretKeyRef:
                 key: PULSAR_MANAGER_ADMIN_PASSWORD
@@ -89,6 +92,7 @@ spec:
                 {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
                 {{- end }}
+          {{- end }}
           - name: PULSAR_MANAGER_OPTS
             value: "$(PULSAR_MANAGER_OPTS) -Dlog4j2.formatMsgNoLookups=true"
         {{- include "pulsar.imagePullSecrets" . | nindent 6}}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -125,7 +125,7 @@ components:
   # toolset
   toolset: true
   # pulsar manager
-  pulsar_manager: true
+  pulsar_manager: false
 
 ## Monitoring Components
 ##
@@ -1104,9 +1104,7 @@ pulsar_manager:
   configData:
     REDIRECT_HOST: "http://127.0.0.1"
     REDIRECT_PORT: "9527"
-    DRIVER_CLASS_NAME: org.postgresql.Driver
-    URL: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
-    LOG_LEVEL: DEBUG
+    LOGGING_LEVEL_ROOT: INFO
     ## If you enabled authentication support
     ## JWT_TOKEN: <token>
     ## SECRET_KEY: data:base64,<secret key>
@@ -1135,6 +1133,10 @@ pulsar_manager:
 
   ## If set use existing secret with specified name to set pulsar admin credentials.
   existingSecretName:
+  userManagement:
+    # when enabled, will use the pulsar manager database for user management
+    enabled: false
+  # the admin user and password will only be used when pulsar_manager.userManagement.enabled=false
   admin:
     user: pulsar
     password: pulsar


### PR DESCRIPTION
Fixes #31 
Fixes #108

### Motivation

- configuration for pulsar_manager is outdated and doesn't work

### Modifications

- disable pulsar_manager by default because of security reasons

- set properties compatible with pulsar-manager v0.2.0,
  https://github.com/apache/pulsar-manager/blob/v0.2.0/src/main/resources/application.properties#L87-L91

- remove obsolete environment variables