### PR TITLE
Don't enable pulsar manager by default

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -125,7 +125,7 @@ components:
   # toolset
   toolset: true
   # pulsar manager
-  pulsar_manager: true
+  pulsar_manager: false
 
 ## Monitoring Components
 ##


### PR DESCRIPTION
### Motivation

- because of security reasons
  - it increases the attack surface
  - pulsar manager cannot be run as non-root user, issue reported as https://github.com/apache/pulsar-manager/issues/407
- it's an unnecessary feature for most users
  - wasted resource consumption