### PR TITLE
Wrap Zookeeper probe script with timeout command

### DIFF
--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -149,6 +149,8 @@ spec:
         readinessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeeper.probe.readiness.timeoutSeconds }}"
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
@@ -159,6 +161,8 @@ spec:
         livenessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeeper.probe.liveness.timeoutSeconds }}"
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
@@ -169,6 +173,8 @@ spec:
         startupProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeeper.probe.startup.timeoutSeconds }}"
             - bin/pulsar-zookeeper-ruok.sh
           initialDelaySeconds: {{ .Values.zookeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.startup.periodSeconds }}


### PR DESCRIPTION
### Motivation

Run Zookeeper probes with timeout command so that the probe doesn't continue running indefinitely.

It seems that the probe will get stuck because of https://issues.apache.org/jira/browse/ZOOKEEPER-3988 / https://github.com/apache/pulsar/issues/11070 .

### Modifications

- wrap Zookeeper probe script with [timeout](https://www.gnu.org/software/coreutils/timeout) (included in Docker image, [timeout](https://www.gnu.org/software/coreutils/timeout) is part of gnu coreutils package)


### Additional context

This PR resolves the issue with Kubernetes <1.20
"Before Kubernetes 1.20, the field timeoutSeconds was not respected for exec probes: probes continued running indefinitely, even past their configured deadline, until a result was returned."
described in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

- #179 already fixed the issue for Kubernetes 1.20+
