### PR TITLE
Increase Zookeeper probe timeouts

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -320,19 +320,19 @@ zookeeper:
       failureThreshold: 10
       initialDelaySeconds: 20
       periodSeconds: 30
-      timeoutSeconds: 5
+      timeoutSeconds: 30
     readiness:
       enabled: true
       failureThreshold: 10
       initialDelaySeconds: 20
       periodSeconds: 30
-      timeoutSeconds: 5
+      timeoutSeconds: 30
     startup:
       enabled: false
       failureThreshold: 30
       initialDelaySeconds: 20
       periodSeconds: 30
-      timeoutSeconds: 5
+      timeoutSeconds: 30
   affinity:
     anti_affinity: true
     # Set the anti affinity type. Valid values:


### PR DESCRIPTION
### Motivation

- 5 seconds seems to be too short a probe timeout on a system with low resources, such as in CI

### Modifications

- change default timeout to 30 seconds (which matches the probe's periodSeconds parameter)