### PR TITLE
[Proxy] Configure metadata settings for Proxy

### DIFF
--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -31,8 +31,7 @@ data:
   zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- if .Values.pulsar_metadata.configurationStore }}
   configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
-  {{- end }}
-  {{- if not .Values.pulsar_metadata.configurationStore }}
+  {{- else }}
   configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- end }}
 

--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -27,6 +27,15 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
 data:
+  # Metadata settings
+  zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- if .Values.pulsar_metadata.configurationStore }}
+  configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  {{- end }}
+  {{- if not .Values.pulsar_metadata.configurationStore }}
+  configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- end }}
+
   clusterName: {{ template "pulsar.cluster.name" . }}
   httpNumThreads: "8"
   statusFilePath: "{{ template "pulsar.home" . }}/status"


### PR DESCRIPTION
### Motivation

- enables service discovery in the proxy
- required by https://github.com/apache/pulsar/pull/14078 changes

### Modifications

- configure `zookeeperServers` and `configurationStoreServers` for the Proxy to enable service discovery
