### PR TITLE
Improve Zookeeper "ruok" probes: use TLS port when TLS is enabled, specify "-q 1" for nc

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.11
+version: 2.7.12
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -141,6 +141,12 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+        {{- $zkConnectCommand := "" -}}
+        {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+        {{- $zkConnectCommand = print "openssl s_client -quiet -crlf -connect localhost:" .Values.zookeeper.ports.clientTls " -cert /pulsar/certs/zookeeper/tls.crt -key /pulsar/certs/zookeeper/tls.key" -}}
+        {{- else -}}
+        {{- $zkConnectCommand = print "nc -q 1 localhost " .Values.zookeeper.ports.client -}}
+        {{- end }}
         {{- if .Values.zookeeper.probe.readiness.enabled }}
         {{- if and .Values.rbac.enabled .Values.rbac.psp }}
         securityContext:
@@ -153,7 +159,7 @@ spec:
             - "{{ .Values.zookeeper.probe.readiness.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
+            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.readiness.timeoutSeconds }}
@@ -167,7 +173,7 @@ spec:
             - "{{ .Values.zookeeper.probe.liveness.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
+            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.liveness.timeoutSeconds }}
@@ -181,7 +187,7 @@ spec:
             - "{{ .Values.zookeeper.probe.startup.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
+            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.startup.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.startup.timeoutSeconds }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -151,7 +151,9 @@ spec:
             command:
             - timeout
             - "{{ .Values.zookeeper.probe.readiness.timeoutSeconds }}"
-            - bin/pulsar-zookeeper-ruok.sh
+            - bash
+            - -c
+            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.readiness.timeoutSeconds }}
@@ -163,7 +165,9 @@ spec:
             command:
             - timeout
             - "{{ .Values.zookeeper.probe.liveness.timeoutSeconds }}"
-            - bin/pulsar-zookeeper-ruok.sh
+            - bash
+            - -c
+            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.liveness.timeoutSeconds }}
@@ -175,7 +179,9 @@ spec:
             command:
             - timeout
             - "{{ .Values.zookeeper.probe.startup.timeoutSeconds }}"
-            - bin/pulsar-zookeeper-ruok.sh
+            - bash
+            - -c
+            - 'echo ruok | nc -q 1 localhost 2181 | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.startup.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.startup.timeoutSeconds }}


### PR DESCRIPTION
### Motivation

There seem to be problems with the Zookeeper "ruok" probes when using recent version of Zookeeper with org.apache.zookeeper.server.NettyServerCnxnFactory . @frederic-kneier contributed a fix in https://github.com/apache/pulsar/pull/14088 where `-q 1` parameter is added to the `nc` command.
In addition, there's a need to monitor the TLS port when TLS is enabled. This change uses openssl s_client to the TLS port in that case.

### Credits

Kudos to @frederic-kneier for contributing the `-q 1` solution in https://github.com/apache/pulsar/pull/14088.

### Modications

Replace `bin/pulsar-zookeeper-ruok.sh` probe with `bash -c 'echo ruok | nc -q 1 localhost 2181 | grep imok'`.
When TLS is enabled, the command will be `bash -c 'echo ruok | openssl s_client -quiet -crlf -connect localhost:2281 -cert /pulsar/certs/zookeeper/tls.crt -key /pulsar/certs/zookeeper/tls.key | grep imok'`. [A similar approach is used in the Bitnami Zookeeper Helm chart for Zookeeper probes](https://github.com/bitnami/charts/blob/5b659dea765218500a85c33a40361db0bec040bf/bitnami/zookeeper/templates/statefulset.yaml#L355).

### Additional context

Here's some parts of the man page for netcat-openbsd nc
```
    -N      shutdown(2) the network socket after EOF on the input.  Some servers require this to finish their work.

     -q seconds
             after EOF on stdin, wait the specified number of seconds and then quit. If seconds is negative, wait forever (default).  Specifying a non-negative seconds implies -N.
```

There's some explanation in https://stackoverflow.com/questions/4160347/close-vs-shutdown-socket/23483487 about shutdown vs. close for TCP sockets. When specifying `-q `, netcat (nc) will call "shutdown" for the socket after waiting for 1 socket. This sends a TCP FIN to the other end and starts a clean connection shutdown. I guess that the default for netcat-openbsd is that it will wait for the other end to close the connection unless `-q 1` is specified.
This feels like a bug in Zookeeper.
