### PR TITLE
Allow us to turn on PodSecurityPolicy for Pulsar clusters with the same name deployed in different K8S namespaces in the same cluster

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.10
+version: 2.7.11
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/autorecovery-rbac.yaml
+++ b/charts/pulsar/templates/autorecovery-rbac.yaml
@@ -59,8 +59,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/bookkeeper-rbac.yaml
+++ b/charts/pulsar/templates/bookkeeper-rbac.yaml
@@ -59,8 +59,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -97,8 +97,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/proxy-rbac.yaml
+++ b/charts/pulsar/templates/proxy-rbac.yaml
@@ -59,8 +59,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/toolset-rbac.yaml
+++ b/charts/pulsar/templates/toolset-rbac.yaml
@@ -59,8 +59,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false

--- a/charts/pulsar/templates/zookeeper-rbac.yaml
+++ b/charts/pulsar/templates/zookeeper-rbac.yaml
@@ -59,8 +59,11 @@ subjects:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-  namespace: {{ template "pulsar.namespace" . }}
+{{- if .Values.rbac.limit_to_namespace }}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ template "pulsar.namespace" . }}"
+{{- else}}
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}" 
+{{- end}}
 spec:
   readOnlyRootFilesystem: false
   privileged: false


### PR DESCRIPTION
(PodSecurityPolicy is a cluster-level-resource so we are creating new PSPs by appending the pulsar namespace)

Fixes #<xyz>

### Motivation

* We want to be able to deploy multiple Pulsar clusters in different K8S namespaces but having the same helm release name. 

### Modifications

* PodSecurityPolicies are cluster-wide so to avoid clashing we need to distinguish each Pulsar Cluster PSP somehow so we appended the `pulsar.namespace` value
* For backwards compatiblity we keyed off of `rbac.limit_to_namespace` which by default is `false`
https://github.com/apache/pulsar-helm-chart/blob/master/charts/pulsar/values.yaml#L93
### Verifying this change

- [ ] Make sure that the change passes the CI checks.
