### PR TITLE
allow specifying the nodeSelector for the init jobs

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -32,6 +32,9 @@ spec:
     {{- if and .Values.rbac.enabled .Values.rbac.psp }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
     {{- end }}
+      {{- if .Values.initialize_jobs.nodeSelector }}
+{{ toYaml .Values.initialize_jobs | indent 6 }}
+      {{- end }}
       initContainers:
       - name: wait-zookeeper-ready
         image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -32,8 +32,9 @@ spec:
     {{- if and .Values.rbac.enabled .Values.rbac.psp }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
     {{- end }}
-      {{- if .Values.initialize_jobs.nodeSelector }}
-{{ toYaml .Values.initialize_jobs | indent 6 }}
+      nodeSelector:
+      {{- if .Values.pulsar_metadata.nodeSelector }}
+{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}
       initContainers:
       - name: wait-zookeeper-ready

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -30,8 +30,9 @@ metadata:
 spec:
   template:
     spec:
-    {{- if .Values.initialize_jobs.nodeSelector }}
-{{ toYaml .Values.initialize_jobs | indent 6 }}
+    {{- if .Values.pulsar_metadata.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
     {{- end }}
       initContainers:
       {{- if .Values.pulsar_metadata.configurationStore }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -30,6 +30,9 @@ metadata:
 spec:
   template:
     spec:
+    {{- if .Values.initialize_jobs.nodeSelector }}
+{{ toYaml .Values.initialize_jobs | indent 6 }}
+    {{- end }}
       initContainers:
       {{- if .Values.pulsar_metadata.configurationStore }}
       - name: wait-cs-ready
@@ -41,7 +44,6 @@ spec:
             until nslookup {{ .Values.pulsar_metadata.configurationStore}}; do
               sleep 3;
             done;
-
       {{- end }}
       - name: wait-zookeeper-ready
         image: "{{ .Values.pulsar_metadata.image.repository }}:{{ .Values.pulsar_metadata.image.tag }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -652,6 +652,9 @@ pulsar_metadata:
   # configurationStore:
   configurationStoreMetadataPrefix: ""
   configurationStorePort: 2181
+  ## optional you can specify a nodeSelector for all init jobs (pulsar-init & bookkeeper-init)
+  # nodeSelector:
+    # cloud.google.com/gke-nodepool: default-pool
 
   ## optional, you can provide your own zookeeper metadata store for other components
   # to use this, you should explicit set components.zookeeper to false


### PR DESCRIPTION
### Motivation

When deploying pulsar to an AKS cluster with windows nodepools i was unable to specify that the Jobs of the initalize release had to run on linux nodes. With the change i can now specify a node selector for the init jobs.

### Modifications

add nodeSelector on pulsar_init and bookie_init

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
