### PR TITLE
Fixed release yaml file

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -71,9 +71,9 @@ function release::git_setup() {
 
 function release::publish_charts() {
     release::git_setup
-    git clone https://${GITHUB_TOKEN}@github.com/apache/pulsar
+    git clone https://${GITHUB_TOKEN}@github.com/apache/pulsar-site
     cd pulsar
-    git checkout asf-site
+    git checkout asf-site-next
     mkdir -p content/charts
     cp --force ${CHARTS_INDEX}/index.yaml content/charts/index.yaml
     git add content/charts/index.yaml

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -72,7 +72,7 @@ function release::git_setup() {
 function release::publish_charts() {
     release::git_setup
     git clone https://${GITHUB_TOKEN}@github.com/apache/pulsar-site
-    cd pulsar
+    cd pulsar-site
     git checkout asf-site-next
     mkdir -p content/charts
     cp --force ${CHARTS_INDEX}/index.yaml content/charts/index.yaml


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

This update fixes an issue with the site release that caused the helm chart to no longer be used. 

Exception: 
```
...Unable to get an update from the "apache-pulsar" chart repository (https://pulsar.apache.org/charts):
	failed to fetch https://pulsar.apache.org/charts/index.yaml : 404 Not Found
```

### Modifications

* Update release yaml file

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
