### PR TITLE
Remove completed init jobs using ttl

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.12
+version: 2.7.13
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -27,6 +27,8 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: "{{ .Values.bookkeeper.component }}-init"
 spec:
+# This feature was previously behind a feature gate for several Kubernetes versions and will default to true in 1.23 and beyond
+# https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- if .Values.job.ttl.enabled }}
   ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -27,6 +27,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: "{{ .Values.bookkeeper.component }}-init"
 spec:
+{{- if .Values.job.ttl.enabled }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
+{{- end }}
   template:
     spec:
     {{- if and .Values.rbac.enabled .Values.rbac.psp }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -28,6 +28,8 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_metadata.component }}
 spec:
+# This feature was previously behind a feature gate for several Kubernetes versions and will default to true in 1.23 and beyond
+# https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- if .Values.job.ttl.enabled }}
   ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -28,6 +28,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_metadata.component }}
 spec:
+{{- if .Values.job.ttl.enabled }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
+{{- end }}
   template:
     spec:
       initContainers:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1140,6 +1140,9 @@ pulsar_manager:
     user: pulsar
     password: pulsar
 
+# These are jobs where job ttl configuration is used
+# pulsar-helm-chart/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+# pulsar-helm-chart/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
 job:
   ttl:
     enabled: false

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1139,3 +1139,8 @@ pulsar_manager:
   admin:
     user: pulsar
     password: pulsar
+
+job:
+  ttl:
+    enabled: false
+    secondsAfterFinished: 3600


### PR DESCRIPTION
Remove completed init jobs using ttlSecondsAfterFinished

### Motivation

Cleanup of completed jobs to free up resources and also reduces failures when redeploying pulsar as the jobs are immutable

This feature was previously behind a feature gate for several Kubernetes versions and will default to true in 1.23 and beyond
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

### Modifications

Added ttlSecondsAfterFinished in job spec using feature flag for backward compatibility

### Verifying this change

- [x] Make sure that the change passes the CI checks.
