### PR TITLE
To address the function role vs clusterrole issue

### DIFF
--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -19,7 +19,7 @@
 
 {{- if or .Values.components.functions .Values.extra.functionsAsPods }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.functions.limit_to_namespace }}
+{{- if .Values.functions.rbac.limit_to_namespace }}
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
@@ -52,7 +52,7 @@ metadata:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.functions.limit_to_namespace }}
+{{- if .Values.functions.rbac.limit_to_namespace }}
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-rolebinding"
@@ -63,7 +63,7 @@ metadata:
 {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-{{- if .Values.functions.limit_to_namespace }}
+{{- if .Values.functions.rbac.limit_to_namespace }}
   kind: Role
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
 {{- else}}

--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -19,9 +19,15 @@
 
 {{- if or .Values.components.functions .Values.extra.functionsAsPods }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
+kind: Role
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
+{{- else}}
 kind: ClusterRole
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+{{- end}}
 rules:
 - apiGroups: [""]
   resources:
@@ -46,13 +52,24 @@ metadata:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
+kind: RoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-rolebinding"
+{{- else}}
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrolebinding"
+{{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.limit_to_namespace }}
+  kind: Role
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
+{{- else}}
   kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+{{- end}}
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"

--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -19,14 +19,14 @@
 
 {{- if or .Values.components.functions .Values.extra.functionsAsPods }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.rbac.limit_to_namespace }}
+{{- if .Values.functions.limit_to_namespace }}
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
 {{- else}}
 kind: ClusterRole
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
 {{- end}}
 rules:
 - apiGroups: [""]
@@ -52,23 +52,23 @@ metadata:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.rbac.limit_to_namespace }}
+{{- if .Values.functions.limit_to_namespace }}
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-rolebinding"
 {{- else}}
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrolebinding"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
 {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-{{- if .Values.rbac.limit_to_namespace }}
+{{- if .Values.functions.limit_to_namespace }}
   kind: Role
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
 {{- else}}
   kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
 {{- end}}
 subjects:
 - kind: ServiceAccount

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -777,6 +777,8 @@ broker:
 functions:
   component: functions-worker
 
+  limit_to_namespace: false
+  
 ## Pulsar: Proxy Cluster
 ## templates/proxy-statefulset.yaml
 ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -776,9 +776,12 @@ broker:
 ##
 functions:
   component: functions-worker
-
+  ## Pulsar: Functions Worker ClusterRole or Role
+  ## templates/broker-rbac.yaml
+  # Default is false which deploys functions with ClusterRole and ClusterRoleBinding at the cluster level
+  # Set to true to deploy functions with Role and RoleBinding inside the specified namespace
   limit_to_namespace: false
-  
+
 ## Pulsar: Proxy Cluster
 ## templates/proxy-statefulset.yaml
 ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -780,7 +780,8 @@ functions:
   ## templates/broker-rbac.yaml
   # Default is false which deploys functions with ClusterRole and ClusterRoleBinding at the cluster level
   # Set to true to deploy functions with Role and RoleBinding inside the specified namespace
-  limit_to_namespace: false
+  rbac:
+    limit_to_namespace: false
 
 ## Pulsar: Proxy Cluster
 ## templates/proxy-statefulset.yaml


### PR DESCRIPTION
Fixes #230

### Motivation

*When functions are enabled it deploys only with clusterrole and clusterrolebinding. However the use case I have is I am unable to use those within a namespace.*

### Modifications

*I followed the example in the already approved file "broker-cluster-role-binding.yaml" for the approach to deal with this issue. It allows for a role and rolebinding or clusterrole and clusterrolebinding and doesn't force you into only one.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
