### PR TITLE
Cert Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This Helm Chart includes all the components of Apache Pulsar for a complete expe
 It includes support for:
 
 - [x] Security
-    - [x] Automatically provisioned TLS certs, using [Jetstack](https://www.jetstack.io/)'s [cert-manager](https://cert-manager.io/docs/)
+    - [x] Automatically provisioned TLS certs, using [Jetstack](https://www.jetstack.io/)'s [cert-manager](https://cert-manager.io/docs/) v1.5.4+
         - [x] self-signed
         - [x] [Let's Encrypt](https://letsencrypt.org/)
     - [x] TLS Encryption

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.13
+version: 2.7.14
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.12
+version: 2.7.13
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -31,15 +31,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -73,15 +75,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -115,15 +119,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -156,15 +162,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -194,15 +202,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -232,15 +242,17 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -215,8 +215,8 @@ tls:
     organization:
       - pulsar
     keySize: 4096
-    keyAlgorithm: rsa
-    keyEncoding: pkcs8
+    keyAlgorithm: RSA
+    keyEncoding: PKCS8
   # settings for generating certs for proxy
   proxy:
     enabled: false


### PR DESCRIPTION
### Motivation

In the scripts folder there is a script to install [cert-manager 1.5.4](https://cert-manager.io/v1.5-docs/usage/certificate/), but the chart's templates do not work with that version.

### Modifications

- Moved `keyAlgorithm`, `keySize`, and `keyEncoding` under the `privateKey` object
- Moved `organization` under subject and renamed to `organizations`
- Bumped Chart Version

### Verifying this change

- [X] Make sure that the change passes the CI checks.
