### PR TITLE
Revert "Upgrade cert-manager to 1.5.4 (#204)"

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.7.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.13
+version: 2.7.14
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -271,7 +271,7 @@ auth:
 ## for components within a Pulsar cluster
 certs:
   internal_issuer:
-    apiVersion: cert-manager.io/v1
+    apiVersion: cert-manager.io/v1alpha2
     enabled: false
     component: internal-cert-issuer
     type: selfsigning

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -21,7 +21,7 @@
 
 NAMESPACE=cert-manager
 NAME=cert-manager
-VERSION=v1.5.4
+VERSION=v1.1.0
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."


### PR DESCRIPTION
This reverts commit 40a4d50923bd93c960a4ef940930177ca80cb77e (#204).

Supporting `cert-manager.io/v1` api version requires changes made in #233 or #238. In addition, the change should be made in a way that it is backwards compatible.
