### PR TITLE
Fix issue that bookkeeper don't support some jvm options anymore on java11

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -567,10 +567,10 @@ bookkeeper:
       -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
-      -XX:+PrintGCDetails
-      -XX:+PrintGCTimeStamps
-      -XX:+PrintGCApplicationStoppedTime
-      -XX:+PrintHeapAtGC
+      -Xlog:gc*
+      -Xlog:::time,level,tags
+      -Xlog:safepoint
+      -Xlog:gc+heap=trace
       -verbosegc
       -Xloggc:/var/log/bookie-gc.log
       -XX:G1LogLevel=finest

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -572,8 +572,7 @@ bookkeeper:
       -Xlog:safepoint
       -Xlog:gc+heap=trace
       -verbosegc
-      -Xloggc:/var/log/bookie-gc.log
-      -XX:G1LogLevel=finest
+      -Xlog:gc:/var/log/bookie-gc.log
     # configure the memory settings based on jvm memory settings
     dbStorage_writeCacheMaxSizeMb: "32"
     dbStorage_readAheadCacheMaxSizeMb: "32"


### PR DESCRIPTION
### Motivation
in pulsar 2.8.x,  there are a few JVM options that the bookkeeper doesn't support anymore. It should be removed from the vaules.yaml as the default configuration. 

suggest helm template default values.yaml keep same change. 

fix in : https://github.com/streamnative/charts/pull/403

### Modifications

in bookie jcm config, remove jvm params:
```
-XX:+PrintGCDetails
-XX:+PrintGCTimeStamps
-XX:+PrintGCApplicationStoppedTime
-XX:+PrintHeapAtGC
 -Xloggc:/var/log/bookie-gc.log
 -XX:G1LogLevel=finest
```
and add jvm params
```
 -Xlog:gc*
-Xlog:::time,level,tags
-Xlog:safepoint
-Xlog:gc+heap=trace
-Xlog:gc:/var/log/bookie-gc.log
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.
