### PR TITLE
Update pulsarctl to v2.9.2.7

### DIFF
--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -25,7 +25,7 @@ fi
 
 OUTPUT=${CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v0.4.0
+PULSARCTL_VERSION=v2.9.2.7
 PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
 export PATH=${HOME}/.pulsarctl/plugins:${PATH}
 


### PR DESCRIPTION
Failure to run prepare_helm_release.sh on darwin arm64

### Motivation

Tried to run 

```bash
./scripts/pulsar/prepare_helm_release.sh -n mynamespace -k pulsar
```

Fails because scripts gets a 404 when downloading a pulsarctl release for v0.4.0 on arm64/darwin


### Modifications

Bumped the pulsarctl versions to latest
