### PR TITLE
Bump version to `2.9.2`

### DIFF
--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -48,7 +48,7 @@ bookkeeper:
   metadata:
     image:
       repository: apachepulsar/pulsar-all
-      tag: 2.6.0
+      tag: 2.9.2
 
 broker:
   replicaCount: 1
@@ -72,24 +72,24 @@ toolset:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2
 
 pulsar_metadata:
   image:
     repository: apachepulsar/pulsar-all
-    tag: 2.6.0
+    tag: 2.9.2

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v2
-appVersion: "2.7.4"
+appVersion: "2.9.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.7.13
+version: 2.9.2
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -163,27 +163,27 @@ extra:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2
@@ -646,7 +646,7 @@ pulsar_metadata:
   image:
     # the image used for running `pulsar-cluster-initialize` job
     repository: apachepulsar/pulsar-all
-    tag: 2.7.4
+    tag: 2.9.2
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -572,8 +572,7 @@ bookkeeper:
       -Xlog:safepoint
       -Xlog:gc+heap=trace
       -verbosegc
-      -Xloggc:/var/log/bookie-gc.log
-      -XX:G1LogLevel=finest
+      -Xlog:gc:/var/log/bookie-gc.log
     # configure the memory settings based on jvm memory settings
     dbStorage_writeCacheMaxSizeMb: "32"
     dbStorage_readAheadCacheMaxSizeMb: "32"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -567,10 +567,10 @@ bookkeeper:
       -XX:-ResizePLAB
       -XX:+ExitOnOutOfMemoryError
       -XX:+PerfDisableSharedMem
-      -XX:+PrintGCDetails
-      -XX:+PrintGCTimeStamps
-      -XX:+PrintGCApplicationStoppedTime
-      -XX:+PrintHeapAtGC
+      -Xlog:gc*
+      -Xlog:gc::utctime
+      -Xlog:safepoint
+      -Xlog:gc+heap=trace
       -verbosegc
       -Xloggc:/var/log/bookie-gc.log
       -XX:G1LogLevel=finest


### PR DESCRIPTION
### Motivation

The docker image Pulsar `2.9.2` is available, bump the chart version to `2.9.2`.

Use Unified JVM Logging. refer to http://openjdk.java.net/jeps/158 and https://openjdk.java.net/jeps/271.

### Modifications

1. Bump the Pulsar image version and app version to `2.9.2`

2. Because the latest Pulsar image is based on Java 11, some JVM param for printing GC information has been deprecated, change to use the unified JVM Logging. Refer to https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5 and https://issues.redhat.com/browse/CLOUD-3040.

**BookKeeper node GC related JVM param**

original param | new param
--|--
`-XX:+PrintGCDetails` | `-Xlog:gc*`
`-XX:+PrintGCApplicationStoppedTime` | `-Xlog:safepoint`
`-XX:+PrintHeapAtGC` | `-Xlog:gc+heap=trace`
`-XX:+PrintGCTimeStamps` | `-Xlog:gc::utctime`
 `-Xloggc:/var/log/bookie-gc.log` | `-Xlog:gc:/var/log/bookie-gc.log`

I didn't find the param to instead `-XX:G1LogLevel=finest`, so remove it first.
      


### Verifying this change

- [ ] Make sure that the change passes the CI checks.
