### PR TITLE
[Proxy] Increase httpNumThreads from 8 to 16

### DIFF
--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -28,7 +28,7 @@ metadata:
     component: {{ .Values.proxy.component }}
 data:
   clusterName: {{ template "pulsar.cluster.name" . }}
-  httpNumThreads: "8"
+  httpNumThreads: "16"
   statusFilePath: "{{ template "pulsar.home" . }}/status"
   # prometheus needs to access /metrics endpoint
   webServicePort: "{{ .Values.proxy.ports.http }}"


### PR DESCRIPTION
- after the recent changes in Pulsar Proxy, the proxy won't start if httpNumThreads is set to 8
  and there are >= cores assigned to the pod

Error message is 
```
Caused by: java.lang.IllegalStateException: Insufficient configured threads: required=8 < max=8 for WebExecutorThreadPool[etp884604029]@34b9fc7d{STARTED,8<=8<=8,i=2,q=0,ReservedThreadExecutor@3fcee3d9{s=0/1,p=0}}
```