### PR TITLE
added pdb version detection

### DIFF
--- a/charts/pulsar/templates/bookkeeper-pdb.yaml
+++ b/charts/pulsar/templates/bookkeeper-pdb.yaml
@@ -20,10 +20,10 @@
 {{- if .Values.components.bookkeeper }}
 {{- if .Values.bookkeeper.pdb.usePolicy }}
 # pdb version detection
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if semverCompare "<1.21.0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/pulsar/templates/bookkeeper-pdb.yaml
+++ b/charts/pulsar/templates/bookkeeper-pdb.yaml
@@ -19,7 +19,12 @@
 
 {{- if .Values.components.bookkeeper }}
 {{- if .Values.bookkeeper.pdb.usePolicy }}
+# pdb version detection
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/bookkeeper-pdb.yaml
+++ b/charts/pulsar/templates/bookkeeper-pdb.yaml
@@ -20,7 +20,7 @@
 {{- if .Values.components.bookkeeper }}
 {{- if .Values.bookkeeper.pdb.usePolicy }}
 # pdb version detection
-{{- if semverCompare "<1.21.0" .Capabilities.KubeVersion.Version }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
 {{- else }}
 apiVersion: policy/v1

--- a/charts/pulsar/templates/broker-pdb.yaml
+++ b/charts/pulsar/templates/broker-pdb.yaml
@@ -19,7 +19,12 @@
 
 {{- if .Values.components.broker }}
 {{- if .Values.broker.pdb.usePolicy }}
+# pdb version detection
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/broker-pdb.yaml
+++ b/charts/pulsar/templates/broker-pdb.yaml
@@ -20,10 +20,10 @@
 {{- if .Values.components.broker }}
 {{- if .Values.broker.pdb.usePolicy }}
 # pdb version detection
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/pulsar/templates/proxy-pdb.yaml
+++ b/charts/pulsar/templates/proxy-pdb.yaml
@@ -19,7 +19,12 @@
 
 {{- if or .Values.components.proxy .Values.extra.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
+# pdb version detection
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/proxy-pdb.yaml
+++ b/charts/pulsar/templates/proxy-pdb.yaml
@@ -20,10 +20,10 @@
 {{- if or .Values.components.proxy .Values.extra.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
 # pdb version detection
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/pulsar/templates/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper-pdb.yaml
@@ -21,7 +21,7 @@
 {{- if .Values.components.zookeeper }}
 {{- if .Values.zookeeper.pdb.usePolicy }}
 # pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersioin.Version }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1beta1
 {{- else }}
 apiVersion: policy/v1

--- a/charts/pulsar/templates/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper-pdb.yaml
@@ -21,10 +21,10 @@
 {{- if .Values.components.zookeeper }}
 {{- if .Values.zookeeper.pdb.usePolicy }}
 # pdb version detection
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersioin.Version }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/pulsar/templates/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper-pdb.yaml
@@ -20,7 +20,12 @@
 # deploy zookeeper only when `components.zookeeper` is true
 {{- if .Values.components.zookeeper }}
 {{- if .Values.zookeeper.pdb.usePolicy }}
+# pdb version detection
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"


### PR DESCRIPTION
Fixes pod disruption budget version warning

### Motivation

PDB policy api version, v1beta1 is deprecated in k8s1.21+ (not available in 1.25+).

### Modifications

zookeeper-pdb, proxy-pdb, broker-pdb and bookkeepr-pdb templates are modified.  If k8s api-resources container policy/v1, the *-pdb.yaml will generate respective apiVersion. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
