### PR TITLE
Add support for Horizontal Pod Autoscaling for Broker and Proxy.

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.9.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.9.2
+version: 2.9.3
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/templates/broker-hpa.yaml
+++ b/charts/pulsar/templates/broker-hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.broker.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+spec:
+  maxReplicas: {{ .Values.broker.autoscaling.maxReplicas }}
+  {{- with .Values.broker.autoscaling.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  minReplicas: {{ .Values.broker.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+{{- end }}

--- a/charts/pulsar/templates/proxy-hpa.yaml
+++ b/charts/pulsar/templates/proxy-hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.proxy.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+spec:
+  maxReplicas: {{ .Values.proxy.autoscaling.maxReplicas }}
+  {{- with .Values.proxy.autoscaling.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  minReplicas: {{ .Values.proxy.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+{{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -668,6 +668,11 @@ broker:
   # so the metrics are correctly rendered in grafana dashboard
   component: broker
   replicaCount: 3
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics: ~
   # If using Prometheus-Operator enable this PodMonitor to discover broker scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:
@@ -784,6 +789,11 @@ proxy:
   # so the metrics are correctly rendered in grafana dashboard
   component: proxy
   replicaCount: 3
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics: ~
   # If using Prometheus-Operator enable this PodMonitor to discover proxy scrape targets
   # Prometheus-Operator does not add scrape targets based on k8s annotations
   podMonitor:


### PR DESCRIPTION
Fixes #261

### Motivation

We would like to reduce the cost of our pulsar usage by being able to autoscale the Pulsar Broker and the Pulsar Proxy
with the Pulsar Load Balancer enabled


### Modifications

Add support for Horizontal Pod Autoscaler on Broker and Proxy (turned off by default for backwards compatibility)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
