### PR TITLE
Enable the pulsar manager in the minikube values

### DIFF
--- a/examples/values-minikube.yaml
+++ b/examples/values-minikube.yaml
@@ -28,6 +28,7 @@ affinity:
 # disable auto recovery
 components:
   autorecovery: false
+  pulsar_manager: true
 
 zookeeper:
   replicaCount: 1


### PR DESCRIPTION
---

Fixes: https://github.com/apache/pulsar/issues/15927

### Motivation

We have documented the using pulsar manager in the Getting started
with helm on the pulsar website. We should enable the pulsar manager
by default in the minikube values.

### Modifications

- enable the pulsar manager by default in the minikube values.
