### PR TITLE
Support defining extra env for broker and proxy statefulsset.

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -227,6 +227,10 @@ spec:
         - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.broker.ports.pulsarssl }}
         {{- end }}
+{{- if .Values.broker.extreEnvs }}
+        env:
+{{ toYaml .Values.broker.extreEnvs | indent 8 }}
+{{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -202,6 +202,10 @@ spec:
         securityContext:
           readOnlyRootFilesystem: false
       {{- end }}
+{{- if .Values.proxy.extreEnvs }}
+        env:
+{{ toYaml .Values.proxy.extreEnvs | indent 8 }}
+{{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -740,6 +740,12 @@ broker:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
+  extreEnvs: []
+#    - name: POD_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: metadata.name
   ## Broker configmap
   ## templates/broker-configmap.yaml
   ##
@@ -856,6 +862,12 @@ proxy:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
+  extreEnvs: []
+#    - name: POD_IP
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: status.podIP
   ## Proxy configmap
   ## templates/proxy-configmap.yaml
   ##


### PR DESCRIPTION
Fixes #272

### Motivation
Allow broker/proxy to define extra envs so user can add env like Pod IP or Pod Name.

### Modifications
Add extra env in broker/proxy sts if defined.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
