### PR TITLE
scripts: provide an error if the namespace was not created

### DIFF
--- a/scripts/pulsar/prepare_helm_release.sh
+++ b/scripts/pulsar/prepare_helm_release.sh
@@ -103,6 +103,13 @@ function do_create_namespace() {
 
 do_create_namespace
 
+kubectl get namespace "${namespace}" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "error: failed to get namespace '${namespace}'"
+  echo "please check that this namespace exists, or use the '-c' option to create it"
+  exit 1
+fi
+
 extra_opts=""
 if [[ "${symmetric}" == "true" ]]; then
   extra_opts="${extra_opts} -s"


### PR DESCRIPTION
This is just a minor improvement to the error handling of one of the bash scripts

### Motivation

Currently if you run `./scripts/pulsar/prepare_helm_release.sh` and the pulsar namespace does not currently exist, you get several error messages that make it not that clear what still needs to be done next.

```
generate the token keys for the pulsar cluster
The private key and public key are generated to /var/folders/cn/r5tb0zln1bgbfzz_7x72tgzm0000gn/T/tmp.ITrq1a4C and /var/folders/cn/r5tb0zln1bgbfzz_7x72tgzm0000gn/T/tmp.qi0dl2WO successfully.
error: failed to create secret namespaces "pulsar" not found
generate the tokens for the super-users: proxy-admin,broker-admin,admin
generate the token for proxy-admin
pulsar-dev-token-asymmetric-key
kubectl get -n pulsar secrets pulsar-dev-token-asymmetric-key -o jsonpath={.data.PRIVATEKEY} | base64 --decode > /var/folders/cn/r5tb0zln1bgbfzz_7x72tgzm0000gn/T/tmp.CikEhIxe
Error from server (NotFound): namespaces "pulsar" not found
generate the token for broker-admin
pulsar-dev-token-asymmetric-key
kubectl get -n pulsar secrets pulsar-dev-token-asymmetric-key -o jsonpath={.data.PRIVATEKEY} | base64 --decode > /var/folders/cn/r5tb0zln1bgbfzz_7x72tgzm0000gn/T/tmp.G1PU9MMj
Error from server (NotFound): namespaces "pulsar" not found
generate the token for admin
pulsar-dev-token-asymmetric-key
kubectl get -n pulsar secrets pulsar-dev-token-asymmetric-key -o jsonpath={.data.PRIVATEKEY} | base64 --decode > /var/folders/cn/r5tb0zln1bgbfzz_7x72tgzm0000gn/T/tmp.HddlCq8e
Error from server (NotFound): namespaces "pulsar" not found
-------------------------------------

The jwt token secret keys are generated under:
    - 'pulsar-dev-token-asymmetric-key'

The jwt tokens for superusers are generated and stored as below:
    - 'proxy-admin':secret('pulsar-dev-token-proxy-admin')
    - 'broker-admin':secret('pulsar-dev-token-broker-admin')
    - 'admin':secret('pulsar-dev-token-admin')
```

### Modifications

I added a check for the existence of the namespace which fails immediately instead of continuing, and added an error message that describes what the problem is and how to resolve it.

```
error: failed to get namespace 'pulsar'
please check that this namespace exists, or use the '-c' option to create it
```

### Verifying this change

- [X] Make sure that the change passes the CI checks.
