### PR TITLE
Bump Apache Pulsar version to 2.9.3

### DIFF
--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -45,10 +45,6 @@ bookkeeper:
     diskUsageWarnThreshold: "0.999"
     PULSAR_PREFIX_diskUsageThreshold: "0.999"
     PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
-  metadata:
-    image:
-      repository: apachepulsar/pulsar-all
-      tag: 2.9.3
 
 broker:
   replicaCount: 1
@@ -66,30 +62,3 @@ proxy:
 
 toolset:
   useProxy: false
-
-# use pulsar image
-
-images:
-  zookeeper:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-  bookie:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-  autorecovery:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-  broker:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-  functions:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-  proxy:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3
-
-pulsar_metadata:
-  image:
-    repository: apachepulsar/pulsar-all
-    tag: 2.9.3

--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -48,7 +48,7 @@ bookkeeper:
   metadata:
     image:
       repository: apachepulsar/pulsar-all
-      tag: 2.9.2
+      tag: 2.9.3
 
 broker:
   replicaCount: 1
@@ -72,24 +72,24 @@ toolset:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
 
 pulsar_metadata:
   image:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "2.9.3"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 2.9.3
+version: 2.9.4
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "2.9.2"
+appVersion: "2.9.3"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 2.9.3

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -652,7 +652,7 @@ pulsar_metadata:
   image:
     # the image used for running `pulsar-cluster-initialize` job
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -163,27 +163,27 @@ extra:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
     pullPolicy: IfNotPresent
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.9.2
+    tag: 2.9.3
   prometheus:
     repository: prom/prometheus
     tag: v2.17.2


### PR DESCRIPTION
### Motivation

Bump Apache Pulsar version to 2.9.3

### Modifications

- Bump Apache Pulsar version to 2.9.3

### Verifying this change

- [x] Make sure that the change passes the CI checks.
