### PR TITLE
Make included prometheus server configurable

### DIFF
--- a/charts/pulsar/templates/prometheus-configmap.yaml
+++ b/charts/pulsar/templates/prometheus-configmap.yaml
@@ -29,38 +29,5 @@ metadata:
 data:
   # Include prometheus configuration file, setup to monitor all the
   # Kubernetes pods with the "scrape=true" annotation.
-  prometheus.yml: |
-    global:
-      scrape_interval: 15s
-    scrape_configs:
-    - job_name: 'prometheus'
-      static_configs:
-      - targets: ['localhost:9090']
-    - job_name: 'kubernetes-pods'
-      kubernetes_sd_configs:
-      - role: pod
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-        action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-        target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_pod_label_component]
-        action: replace
-        target_label: job
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod_name
+{{ toYaml .Values.prometheus.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1061,6 +1061,45 @@ prometheus:
   service:
     annotations: {}
 
+  ## Prometheus configuration
+  ## templates/prometheus-configmap.yaml
+  ##
+  configData:
+      prometheus.yml: |
+        global:
+          scrape_interval: 15s
+        scrape_configs:
+        - job_name: 'prometheus'
+          static_configs:
+          - targets: ['localhost:9090']
+        - job_name: 'kubernetes-pods'
+          kubernetes_sd_configs:
+          - role: pod
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_label_component]
+            action: replace
+            target_label: job
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
+
 ## Monitoring Stack: Grafana
 ## templates/grafana-deployment.yaml
 ##


### PR DESCRIPTION
Fixes #278

### Motivation

We want to connect the included Prometheus server to an external Alert Manager which is currently not possible.

### Modifications

We have moved the hard coded configuration from `templates/prometheus-configmap.yaml` to `prometheus.configData` in `values.yaml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
