### PR TITLE
Allow setting nodePort Option for proxy service

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,22 +37,28 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
+      {{- if .Values.proxy.service.adminNodePort }}
+      nodePort: {{ .Values.proxy.service.adminNodePort }}
+      {{- end }}
     - name: "{{ .Values.tcpPrefix }}pulsar"
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
-      {{- if .Values.proxy.service.nodePort }}
-      nodePort: {{ .Values.proxy.service.nodePort }}
+      {{- if .Values.proxy.service.pulsarNodePort }}
+      nodePort: {{ .Values.proxy.service.pulsarNodePort }}
       {{- end }}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
+      {{- if .Values.proxy.service.adminNodePort }}
+      nodePort: {{ .Values.proxy.service.adminNodePort }}
+      {{- end }}
     - name: "{{ .Values.tlsPrefix }}pulsarssl"
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
-      {{- if .Values.proxy.service.nodePort }}
-      nodePort: {{ .Values.proxy.service.nodePort }}
+      {{- if .Values.proxy.service.pulsarNodePort }}
+      nodePort: {{ .Values.proxy.service.pulsarNodePort }}
       {{- end }}
     {{- end }}
   selector:

--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -40,6 +40,9 @@ spec:
     - name: "{{ .Values.tcpPrefix }}pulsar"
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
+      {{- if .Values.proxy.service.nodePort }}
+      nodePort: {{ .Values.proxy.service.nodePort }}
+      {{- end }}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
@@ -48,6 +51,9 @@ spec:
     - name: "{{ .Values.tlsPrefix }}pulsarssl"
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
+      {{- if .Values.proxy.service.nodePort }}
+      nodePort: {{ .Values.proxy.service.nodePort }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -903,6 +903,9 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
+  ## Possibility to specify a specific NodePort if you set proxy.service.type to 'NodePort'.
+  ## Uncomment only if you set proxy.service.type to 'NodePort'.
+  # nodePort: 32000
   ## Proxy ingress
   ## templates/proxy-ingress.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -903,9 +903,10 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
-  ## Possibility to specify a specific NodePort if you set proxy.service.type to 'NodePort'.
-  ## Uncomment only if you set proxy.service.type to 'NodePort'.
-  # nodePort: 32000
+  ## Possibility to specify a specific NodePort for Pulsar (pulsarNodePort), and/ or the admin service (adminNodePort) if you set proxy.service.type to 'NodePort'.
+  ## Uncomment the following two lines only if you set proxy.service.type to 'NodePort'.
+  # pulsarNodePort: 32000
+  # adminNodePort: 32001
   ## Proxy ingress
   ## templates/proxy-ingress.yaml
   ##


### PR DESCRIPTION
Fixes #281

### Motivation

We can not set a specific nodePort for the proxy service. We want to persist a specific nodePort to make the Chart redeployable in our infrastructure.

### Modifications

We add the `proxy.service.nodePort` option to the `values.yaml`. If set, it will be included in the proxy service definition (`templates/proxy-service.yaml`).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
