### PR TITLE
Add nodeSelector to cluster initialize pod

### DIFF
--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -114,5 +114,9 @@ spec:
       volumes:
       {{- include "pulsar.toolset.certs.volumes" . | nindent 6 }}
       restartPolicy: OnFailure
+      {{- if .Values.pulsar_metadata.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 6 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -116,7 +116,7 @@ spec:
       restartPolicy: OnFailure
       {{- if .Values.pulsar_metadata.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 6 }}
+{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -663,6 +663,9 @@ pulsar_metadata:
   # to use this, you should explicit set components.zookeeper to false
   #
   # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
+  
+  ## optiona, you can specify where to run pulsar-cluster-initialize job
+  # nodeSelector:
 
 # Can be used to run extra commands in the initialization jobs e.g. to quit istio sidecars etc.
 extraInitCommand: ""

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -664,7 +664,7 @@ pulsar_metadata:
   #
   # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
   
-  ## optiona, you can specify where to run pulsar-cluster-initialize job
+  ## optional, you can specify where to run pulsar-cluster-initialize job
   # nodeSelector:
 
 # Can be used to run extra commands in the initialization jobs e.g. to quit istio sidecars etc.


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

Add an option to choose where to run pulsar-cluster-initialize pod. Sometimes there is a necessity to run only on certain nodes.

### Modifications

Added nodeSelector option to the pulsar-cluster-initialize job.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
