### PR TITLE
Upgrade prometheus docker image to 2.39.1

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -186,7 +186,7 @@ images:
     tag: 2.9.3
   prometheus:
     repository: prom/prometheus
-    tag: v2.17.2
+    tag: v2.39.1
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s


### PR DESCRIPTION
Master Issue #294 

### Motivation

The current prometheus version is very out of date. We need to upgrade to the latest version. This will trigger a major version bump in the helm chart.

### Modifications

* Upgrade prometheus from 2.12.2 to 2.39.1

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
