### PR TITLE
Upgrade to grafana 9.2.0

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -189,8 +189,8 @@ images:
     tag: v2.17.2
     pullPolicy: IfNotPresent
   grafana:
-    repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.16
+    repository: grafana/grafana-oss
+    tag: 9.2.0
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: apachepulsar/pulsar-manager


### PR DESCRIPTION
Master Issue #294 

### Motivation

The current grafana version is very out of date. We need to upgrade to the latest version. This will trigger a major version bump in the helm chart.

Note that the previous distribution of the Grafana docker image had StreamNative's grafana dashboards. This was convenient for shipping dashboards, but is not the recommended way to deliver dashboards. In the long term, I think we should switch to using the kube prometheus stack and should mount grafana dashboards as config maps. Note that this kind of change is part of modernizing the helm chart and would help address this long standing issue #65.

We'll need to solve this problem before releasing the next version of the helm chart.

Here is a reference to this chart: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack.

### Modifications

* Upgrade grafana from `streamnative/apache-pulsar-grafana-dashboard-k8s:0.0.16` to `grafana/grafana-oss:9.2.0`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
