### PR TITLE
Allow bk cluster init pod to restart on failure

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -88,6 +88,6 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- include "pulsar.toolset.certs.volumes" . | nindent 6 }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Motivation

This is essentially the same as https://github.com/apache/pulsar-helm-chart/pull/176. Without this change, an init pod can fail and be in `Error` state even though the second pod succeeded. This will prevent misleading errors.

### Modifications

* Replace `Never` with `OnFailure`

### Verifying this change

This is a trivial change.