### PR TITLE
Remove '|| yes' in bk cluster init script

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -70,7 +70,7 @@ spec:
                 echo "bookkeeper cluster already initialized";
             else
                 {{- if not (eq .Values.metadataPrefix "") }}
-                bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} create {{ .Values.metadataPrefix }} 'created for pulsar cluster "{{ template "pulsar.cluster.name" . }}"' || yes &&
+                bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} create {{ .Values.metadataPrefix }} 'created for pulsar cluster "{{ template "pulsar.cluster.name" . }}"' &&
                 {{- end }}
                 bin/bookkeeper shell initnewcluster;
             fi


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar-helm-chart/commit/48501ebe84b5b339189ee145c6cf5c291aff6063#commitcomment-87109075 for details.

Essentially, after #303, we want to make sure that the script actually fails when it fails so that the container gets restarted.

### Modifications

* Remove `|| yes` from bookkeeper init script

### Verifying this change

This is a trivial change.
