### PR TITLE
[test] Add a consumer to the helm tests

### DIFF
--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -41,8 +41,8 @@ fi
 # install pulsar chart
 ci::install_pulsar_chart ${PULSAR_HOME}/${VALUES_FILE} ${extra_opts}
 
-# test producer
-ci::test_pulsar_producer
+# test producer/consumer
+ci::test_pulsar_producer_consumer
 
 if [[ "x${FUNCTION}" == "xtrue" ]]; then
     # install cert manager

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -163,7 +163,7 @@ function ci::install_pulsar_chart() {
     # ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'until [ "$(curl -L http://pulsar-ci-proxy:8080/status.html)" == "OK" ]; do sleep 3; done'
 }
 
-function ci::test_pulsar_producer() {
+function ci::test_pulsar_producer_consumer() {
     sleep 120
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'until nslookup pulsar-ci-broker; do sleep 3; done'
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'until nslookup pulsar-ci-proxy; do sleep 3; done'
@@ -173,7 +173,10 @@ function ci::test_pulsar_producer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -ro
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin tenants create pulsar-ci
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin namespaces create pulsar-ci/test
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin topics create pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin topics create-subscription -s test pulsar-ci/test/test-topic
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client consume -s test pulsar-ci/test/test-topic
 }
 
 function ci::wait_function_running() {


### PR DESCRIPTION
### Motivation

The current tests only produce a message. This test adds a consumer for the produced message.

### Modifications

* Add new section to the test where we consume the produced message
