### PR TITLE
Fix monitoring configuration broken by #299

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-broker-tls.yaml
+++ b/.ci/clusters/values-broker-tls.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-function.yaml
+++ b/.ci/clusters/values-function.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-jwt-asymmetric.yaml
+++ b/.ci/clusters/values-jwt-asymmetric.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-jwt-symmetric.yaml
+++ b/.ci/clusters/values-jwt-symmetric.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-local-pv.yaml
+++ b/.ci/clusters/values-local-pv.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -17,11 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
+kube-prometheus-stack:
+  enabled: false
 
 volumes:
   persistence: false

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -17,12 +17,8 @@
 # under the License.
 #
 
-monitoring:
-  prometheus: false
-  grafana: false
-  node_exporter: false
-  alert_manager: false
-
+kube-prometheus-stack:
+  enabled: false
 
 # disabled AntiAffinity
 affinity:

--- a/examples/values-bookkeeper-aws.yaml
+++ b/examples/values-bookkeeper-aws.yaml
@@ -36,15 +36,9 @@ components:
   # pulsar manager
   pulsar_manager: false
 
-monitoring:
-  # monitoring - prometheus
-  prometheus: false
-  # monitoring - grafana
-  grafana: false
-  # monitoring - node_exporter
-  node_exporter: false
-  # alerting - alert-manager
-  alert_manager: false
+## disable monitoring stack
+kube-prometheus-stack:
+  enabled: false
 
 zookeeper:
   volumes:

--- a/examples/values-cs.yaml
+++ b/examples/values-cs.yaml
@@ -36,10 +36,6 @@ components:
   # pulsar manager
   pulsar_manager: false
 
-monitoring:
-  # monitoring - prometheus
-  prometheus: false
-  # monitoring - grafana
-  grafana: false
-  # monitoring - node_exporter
-  node_exporter: false
+## disable monitoring stack
+kube-prometheus-stack:
+  enabled: false

--- a/examples/values-local-cluster.yaml
+++ b/examples/values-local-cluster.yaml
@@ -28,10 +28,5 @@ components:
   pulsar_manager: true
 
 ## disable monitoring stack
-monitoring:
-  # monitoring - prometheus
-  prometheus: false
-  # monitoring - grafana
-  grafana: false
-  # monitoring - node_exporter
-  node_exporter: false
+kube-prometheus-stack:
+  enabled: false

--- a/examples/values-zookeeper-aws.yaml
+++ b/examples/values-zookeeper-aws.yaml
@@ -36,13 +36,9 @@ components:
   # pulsar manager
   pulsar_manager: false
 
-monitoring:
-  # monitoring - prometheus
-  prometheus: false
-  # monitoring - grafana
-  grafana: false
-  # monitoring - node_exporter
-  node_exporter: false
+## disable monitoring stack
+kube-prometheus-stack:
+  enabled: false
 
 zookeeper:
   configData:


### PR DESCRIPTION
Related to #311

### Motivation

In #299, I updated the values without also updating the test values. As a result, I unintentionally enabled the monitoring stack in the tests and broke some examples. Because we are deploying all resources to a single node. It is possible that we are resource constrained, so I am going to re-disable the monitoring stack.

### Modifications

* Update test cluster configurations to re-disable deploying the monitoring stack
* Update examples with the new configuration

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
