### PR TITLE
Do not require version bump

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ct lint --check-version-increment false --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
### Motivation

With #292, we made the lint CI step require chart version bumps. That is an unnecessary requirement since we have a manual release process. Also, we didn't require it previously.

### Modifications

* Disable chart version bump

### Verifying this change

This is a trivial change.
