### PR TITLE
Fix CI by modifying Chart.yaml and updating ct lint command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: ${{ steps.check_changes.outputs.docs_only != 'true' }}
-        run: ct lint --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --check-version-increment=false --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -25,6 +25,7 @@ version: 2.9.4
 home: https://pulsar.apache.org
 sources:
 - https://github.com/apache/pulsar
+- https://github.com/apache/pulsar-helm-chart
 icon: https://pulsar.apache.org/img/pulsar.svg
 maintainers:
 - name: The Apache Pulsar Team


### PR DESCRIPTION
### Motivation

Fix the CI lint step by modifying the Chart.yaml and by removing the maintainers validation step.