### PR TITLE
Add missing license headers and .rat-excludes

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,3 @@
+.gitignore
+.rat-excludes
+charts/pulsar/Chart.lock

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 .gitignore
-.rat-excludes
-charts/pulsar/Chart.lock
+# Generated Helm file
+Chart.lock

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/charts/pulsar/.helmignore
+++ b/charts/pulsar/.helmignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/charts/pulsar/templates/_autorecovery.tpl
+++ b/charts/pulsar/templates/_autorecovery.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define the pulsar autorecovery service
 */}}
 {{- define "pulsar.autorecovery.service" -}}

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define the pulsar bookkeeper service
 */}}
 {{- define "pulsar.bookkeeper.service" -}}

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define the pulsar brroker service
 */}}
 {{- define "pulsar.broker.service" -}}

--- a/charts/pulsar/templates/_configurationstore.tpl
+++ b/charts/pulsar/templates/_configurationstore.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define configuration store endpoint
 */}}
 {{- define "pulsar.configurationStore.service" -}}

--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -1,3 +1,22 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 
 {{/*

--- a/charts/pulsar/templates/_toolset.tpl
+++ b/charts/pulsar/templates/_toolset.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define the pulsar toolset service
 */}}
 {{- define "pulsar.toolset.service" -}}

--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -1,4 +1,23 @@
 {{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
 Define the pulsar zookeeper
 */}}
 {{- define "pulsar.zookeeper.service" -}}


### PR DESCRIPTION
### Motivation

As part of our updated release process, we need to make sure that all relevant files have license headers.

### Modifications

* Add license headers formatted appropriately for each file type

### Verifying this change

The follow script shows that the solution is complete:

```shell
$ java -jar ../apache-rat-0.15/apache-rat-0.15.jar . -E .rat-excludes 
Ignored 18 lines in your exclusion files as comments or empty lines.


*****************************************************
Summary
-------
Generated at: 2022-10-20T17:54:42-05:00

Notes: 4
Binaries: 1
Archives: 0
Standards: 92

Apache Licensed: 92
Generated Documents: 0

JavaDocs are generated, thus a license header is optional.
Generated files do not require license headers.

0 Unknown Licenses

*****************************************************
  Files with Apache License headers will be marked AL
  Binary files (which do not require any license headers) will be marked B
  Compressed archives will be marked A
  Notices, licenses etc. will be marked N
  AL    ./.asf.yaml
  AL    ./.rat-excludes
  N     ./LICENSE
  N     ./NOTICE
  AL    ./README.md
  AL    ./Vagrantfile
  AL    ./license_test.go
  AL    ./charts/pulsar/.helmignore
  AL    ./charts/pulsar/Chart.yaml
  N     ./charts/pulsar/LICENSE
  N     ./charts/pulsar/NOTICE
  AL    ./charts/pulsar/values.yaml
  B     ./charts/pulsar/charts/kube-prometheus-stack-41.5.1.tgz
  AL    ./charts/pulsar/templates/_autorecovery.tpl
  AL    ./charts/pulsar/templates/_bookkeeper.tpl
  AL    ./charts/pulsar/templates/_broker.tpl
  AL    ./charts/pulsar/templates/_configurationstore.tpl
  AL    ./charts/pulsar/templates/_helpers.tpl
  AL    ./charts/pulsar/templates/_toolset.tpl
  AL    ./charts/pulsar/templates/_zookeeper.tpl
  AL    ./charts/pulsar/templates/autorecovery-configmap.yaml
  AL    ./charts/pulsar/templates/autorecovery-podmonitor.yaml
  AL    ./charts/pulsar/templates/autorecovery-rbac.yaml
  AL    ./charts/pulsar/templates/autorecovery-service.yaml
  AL    ./charts/pulsar/templates/autorecovery-statefulset.yaml
  AL    ./charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
  AL    ./charts/pulsar/templates/bookkeeper-configmap.yaml
  AL    ./charts/pulsar/templates/bookkeeper-pdb.yaml
  AL    ./charts/pulsar/templates/bookkeeper-podmonitor.yaml
  AL    ./charts/pulsar/templates/bookkeeper-rbac.yaml
  AL    ./charts/pulsar/templates/bookkeeper-service.yaml
  AL    ./charts/pulsar/templates/bookkeeper-statefulset.yaml
  AL    ./charts/pulsar/templates/bookkeeper-storageclass.yaml
  AL    ./charts/pulsar/templates/broker-cluster-role-binding.yaml
  AL    ./charts/pulsar/templates/broker-configmap.yaml
  AL    ./charts/pulsar/templates/broker-hpa.yaml
  AL    ./charts/pulsar/templates/broker-pdb.yaml
  AL    ./charts/pulsar/templates/broker-podmonitor.yaml
  AL    ./charts/pulsar/templates/broker-rbac.yaml
  AL    ./charts/pulsar/templates/broker-service-account.yaml
  AL    ./charts/pulsar/templates/broker-service.yaml
  AL    ./charts/pulsar/templates/broker-statefulset.yaml
  AL    ./charts/pulsar/templates/dashboard-deployment.yaml
  AL    ./charts/pulsar/templates/dashboard-ingress.yaml
  AL    ./charts/pulsar/templates/dashboard-service.yaml
  AL    ./charts/pulsar/templates/function-worker-configmap.yaml
  AL    ./charts/pulsar/templates/keytool.yaml
  AL    ./charts/pulsar/templates/namespace.yaml
  AL    ./charts/pulsar/templates/proxy-configmap.yaml
  AL    ./charts/pulsar/templates/proxy-hpa.yaml
  AL    ./charts/pulsar/templates/proxy-ingress.yaml
  AL    ./charts/pulsar/templates/proxy-pdb.yaml
  AL    ./charts/pulsar/templates/proxy-podmonitor.yaml
  AL    ./charts/pulsar/templates/proxy-rbac.yaml
  AL    ./charts/pulsar/templates/proxy-service.yaml
  AL    ./charts/pulsar/templates/proxy-statefulset.yaml
  AL    ./charts/pulsar/templates/pulsar-cluster-initialize.yaml
  AL    ./charts/pulsar/templates/pulsar-manager-admin-secret.yaml
  AL    ./charts/pulsar/templates/pulsar-manager-configmap.yaml
  AL    ./charts/pulsar/templates/pulsar-manager-deployment.yaml
  AL    ./charts/pulsar/templates/pulsar-manager-ingress.yaml
  AL    ./charts/pulsar/templates/pulsar-manager-service.yaml
  AL    ./charts/pulsar/templates/tls-cert-internal-issuer.yaml
  AL    ./charts/pulsar/templates/tls-certs-internal.yaml
  AL    ./charts/pulsar/templates/toolset-configmap.yaml
  AL    ./charts/pulsar/templates/toolset-rbac.yaml
  AL    ./charts/pulsar/templates/toolset-service.yaml
  AL    ./charts/pulsar/templates/toolset-statefulset.yaml
  AL    ./charts/pulsar/templates/zookeeper-configmap.yaml
  AL    ./charts/pulsar/templates/zookeeper-pdb.yaml
  AL    ./charts/pulsar/templates/zookeeper-podmonitor.yaml
  AL    ./charts/pulsar/templates/zookeeper-rbac.yaml
  AL    ./charts/pulsar/templates/zookeeper-service.yaml
  AL    ./charts/pulsar/templates/zookeeper-statefulset.yaml
  AL    ./charts/pulsar/templates/zookeeper-storageclass.yaml
  AL    ./examples/values-bookkeeper-aws.yaml
  AL    ./examples/values-cs.yaml
  AL    ./examples/values-jwt-asymmetric.yaml
  AL    ./examples/values-jwt-symmetric.yaml
  AL    ./examples/values-local-cluster.yaml
  AL    ./examples/values-local-pv.yaml
  AL    ./examples/values-minikube.yaml
  AL    ./examples/values-no-persistence.yaml
  AL    ./examples/values-one-node.yaml
  AL    ./examples/values-tls.yaml
  AL    ./examples/values-zookeeper-aws.yaml
  AL    ./hack/common.sh
  AL    ./hack/kind-cluster-build.sh
  AL    ./scripts/set-pulsar-version.sh
  AL    ./scripts/cert-manager/install-cert-manager.sh
  AL    ./scripts/pulsar/cleanup_helm_release.sh
  AL    ./scripts/pulsar/common.sh
  AL    ./scripts/pulsar/common_auth.sh
  AL    ./scripts/pulsar/generate_token.sh
  AL    ./scripts/pulsar/generate_token_secret_key.sh
  AL    ./scripts/pulsar/get_token.sh
  AL    ./scripts/pulsar/prepare_helm_release.sh
 
*****************************************************

```