### PR TITLE
Zookeeper replicas: adhere to own recommendations

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -281,7 +281,7 @@ zookeeper:
   # so the metrics are correctly rendered in grafana dashboard
   component: zookeeper
   # the number of zookeeper servers to run. it should be an odd number larger than or equal to 3.
-  replicaCount: 1
+  replicaCount: 3
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel


### PR DESCRIPTION
The comments say ZK replicacount should be >=3 but defaults to 1, should adhere to own recommendations by default

### Motivation

The comments state >= 3 but the defaults break this recommendation.

### Modifications

Default `zookeeper.replicaCount` is now 3

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
