### PR TITLE
[Fix] Update pulsarctl version to latest to support Apple M1 arch

### DIFF
--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -25,7 +25,7 @@ fi
 
 OUTPUT=${CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v0.4.0
+PULSARCTL_VERSION=v2.10.2.1
 PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
 export PATH=${HOME}/.pulsarctl/plugins:${PATH}
 


### PR DESCRIPTION
Fixes #338 

### Motivation
Prepare helm release script currently fails for Mac M1s with the error: tar: Error opening archive: Unrecognized archive format
The reason this fails is because common_auth script still points to version 0.4.0 version of pulsarctl that does not support ARM64 which does not download anything in the pulsarctl tar.gz.
Therefore, it needs to be updated.

### Modifications
Updated the common_auth file with the latest pulsarctl version that supports ARM64

### Verifying this change
Fixes the issue:
![image](https://user-images.githubusercontent.com/10327630/204666741-745feea0-a4a0-4a8c-be95-74d2f4018ed9.png)

- [ ] Make sure that the change passes the CI checks.
