### PR TITLE
Respect rbac.limit_to_namespace for Functions RBAC

### DIFF
--- a/charts/pulsar/templates/broker-rbac.yaml
+++ b/charts/pulsar/templates/broker-rbac.yaml
@@ -19,9 +19,15 @@
 
 {{- if or .Values.components.functions .Values.extra.functionsAsPods }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
+kind: Role
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
+{{- else}}
 kind: ClusterRole
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+{{- end}}
 rules:
 - apiGroups: [""]
   resources:
@@ -46,13 +52,26 @@ metadata:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.limit_to_namespace }}
+kind: RoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-rolebinding"
+{{- else}}
 kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrolebinding"
+{{- end}}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.limit_to_namespace }}
+  kind: Role
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-role"
+{{- else}}
   kind: ClusterRole
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-clusterrole"
+{{- end}}
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

The chart already has a `rbac.limit_to_namespace` parameter to replace ClusterRole(Binding)s with Role(Binding)s. This setting is not used for a ClusterRole required by the functions component, which is an issue for deployments in constrained with limited cluster. See #246 

### Modifications

Handle ClusterRole(Binding) for the functions component the same way as for other components: if `rbac.limit_to_namespace` is `true`, use namespaced Role(Binding) instead.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
