### PR TITLE
Fix PVC selector scope error when bookkeeper uses multiple data volumes

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -267,7 +267,7 @@ spec:
     {{- if .storageClassName }}
       storageClassName: "{{ .storageClassName }}"
     {{- end }}
-    {{- with .Values.bookkeeper.volumes.journal.selector }}
+    {{- with $.Values.bookkeeper.volumes.journal.selector }}
       selector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -306,7 +306,7 @@ spec:
     {{- if .storageClassName }}
       storageClassName: "{{ .storageClassName }}"
     {{- end }}
-    {{- with .Values.bookkeeper.volumes.ledgers.selector }}
+    {{- with $.Values.bookkeeper.volumes.ledgers.selector }}
       selector:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
Fix PVC selector scope error when bookkeeper uses multiple data volumes

Fixes # Fix PVC selector scope error when bookkeeper uses multiple data volumes

### Motivation

Bookkeeper error when using multiple data volumes

![image](https://user-images.githubusercontent.com/19341806/206369829-aecd40f1-e395-4f51-bf6a-7ea08b4b7c03.png)


### Modifications

Modify to the correct scope

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
