### PR TITLE
Enable persistence for pulsar-manager

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -19,7 +19,7 @@
 
 {{- if or .Values.components.pulsar_manager .Values.extra.pulsar_manager }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   namespace: {{ template "pulsar.namespace" . }}
@@ -27,6 +27,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
 spec:
+  serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   replicas: 1
   selector:
     matchLabels:
@@ -66,7 +67,7 @@ spec:
           - containerPort: {{ .Values.pulsar_manager.service.targetPort }}
           - containerPort: {{ .Values.pulsar_manager.adminService.targetPort }}
           volumeMounts:
-          - name: pulsar-manager-data
+          - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
             mountPath: /data
           envFrom:
           - configMapRef:
@@ -86,9 +87,30 @@ spec:
                 key: DB_PASSWORD
           - name: PULSAR_MANAGER_OPTS
             value: "$(PULSAR_MANAGER_OPTS) -Dlog4j2.formatMsgNoLookups=true"
-        {{- include "pulsar.imagePullSecrets" . | nindent 6}}
+        {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
       volumes:
-        - name: pulsar-manager-data
-          emptyDir: {}
+      {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.pulsar_manager.volumes.persistence) }}
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
+        emptyDir: {}
+      {{- end }}
+{{- if and (and .Values.persistence .Values.volumes.persistence) .Values.pulsar_manager.volumes.persistence }}
+  volumeClaimTemplates:
+  - metadata:
+      name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.pulsar_manager.volumes.data.size }}
+    {{- if .Values.pulsar_manager.volumes.data.storageClassName }}
+      storageClassName: "{{ .Values.pulsar_manager.volumes.data.storageClassName }}"
+    {{- else if and .Values.volumes.local_storage .Values.pulsar_manager.volumes.data.local_storage }}
+      storageClassName: "local-storage"
+    {{- end }}
+    {{- with .Values.pulsar_manager.volumes.data.selector }}
+      selector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}
 
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1319,6 +1319,21 @@ pulsar_manager:
     # however, feel free to overwrite them
     SPRING_CONFIGURATION_FILE: "/pulsar-manager/pulsar-manager/application.properties"
     PULSAR_MANAGER_OPTS: " -Dlog4j2.formatMsgNoLookups=true"
+  volumes:
+    # use a persistent volume or emptyDir
+    persistence: true
+    data:
+      name: data
+      size: 128Mi
+      local_storage: true
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class,
+      ## If you want to bind static persistent volumes via selectors, e.g.:
+      # selector:
+        # matchLabels:
+        # app: pulsar-bookkeeper-journal
+      selector: {}
   ## Pulsar manager service
   ## templates/pulsar-manager-service.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -184,7 +184,7 @@ images:
     tag:
   pulsar_manager:
     repository: apachepulsar/pulsar-manager
-    tag: v0.3.0
+    tag: v0.4.0
     pullPolicy: IfNotPresent
     hasCommand: false
 


### PR DESCRIPTION
### Motivation

Currently, pulsar-manager volume is not persistent, which means that after a pod restart admin accounts must be [recreated](https://github.com/apache/pulsar-manager#access-pulsar-manager) every time. I want to change that.

### Modifications

Switch pulsar-manager from a Deployment to a StatefulSet and add settings to enable persistence. The settings are inspired by those offered for other components.

Also, the Docker image will always reinitialize the DB, so I made a [PR to fix that too](https://github.com/apache/pulsar-manager/pull/501).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
