### PR TITLE
fix: Set unique advertise address per broker

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -227,8 +227,12 @@ spec:
         - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.broker.ports.pulsarssl }}
         {{- end }}
-{{- if .Values.broker.extreEnvs }}
         env:
+        - name: PULSAR_PREFIX_advertisedAddress
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+{{- if .Values.broker.extreEnvs }}
 {{ toYaml .Values.broker.extreEnvs | indent 8 }}
 {{- end }}
         envFrom:


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

Each but the first broker were failing to register with the cluster. Per `pulsar-admin brokers list use` the first broker was registered with the socket `0.0.0.0:8080` and subsequent brokers attempting to join the cluster failed, since they were competing for the same advertised address.

### Modifications

This PR sets the advertised address uniquely per pod using the Kubernetes downward API to determine the pod's IP.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
