### PR TITLE
Configure custom topologyKey for podAntiAffinity

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.autorecovery.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ .Values.autorecovery.affinity.anti_affinity_topology_key }}
         {{ else }}
           {{ .Values.autorecovery.affinity.type }}:
             - weight: 100
@@ -100,7 +100,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Values.autorecovery.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ .Values.autorecovery.affinity.anti_affinity_topology_key }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.autorecovery.gracePeriod }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.bookkeeper.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ .Values.bookkeeper.affinity.anti_affinity_topology_key }}
         {{ else }}
           {{ .Values.bookkeeper.affinity.type }}:
             - weight: 100
@@ -97,7 +97,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Values.bookkeeper.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ .Values.bookkeeper.affinity.anti_affinity_topology_key }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.broker.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
         {{ else }}
           {{ .Values.broker.affinity.type }}:
             - weight: 100
@@ -98,7 +98,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Values.broker.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.broker.gracePeriod }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.proxy.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ .Values.proxy.affinity.anti_affinity_topology_key }}
         {{ else }}
           {{ .Values.proxy.affinity.type }}:
             - weight: 100
@@ -97,7 +97,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Values.proxy.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ .Values.proxy.affinity.anti_affinity_topology_key }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.zookeeper.component }}
-            topologyKey: "kubernetes.io/hostname"
+            topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
         {{ else }}
           {{ .Values.zookeeper.affinity.type }}:
             - weight: 100
@@ -94,7 +94,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Values.zookeeper.component }}
-                topologyKey: "kubernetes.io/hostname"
+                topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
         {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -321,6 +321,7 @@ zookeeper:
       timeoutSeconds: 30
   affinity:
     anti_affinity: true
+    anti_affinity_topology_key: kubernetes.io/hostname
     # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
@@ -460,6 +461,7 @@ bookkeeper:
       timeoutSeconds: 5
   affinity:
     anti_affinity: true
+    anti_affinity_topology_key: kubernetes.io/hostname
     # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
@@ -621,6 +623,7 @@ autorecovery:
     # cloud.google.com/gke-nodepool: default-pool
   affinity:
     anti_affinity: true
+    anti_affinity_topology_key: kubernetes.io/hostname
     # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
@@ -721,6 +724,7 @@ broker:
       timeoutSeconds: 5
   affinity:
     anti_affinity: true
+    anti_affinity_topology_key: kubernetes.io/hostname
     # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
@@ -842,6 +846,7 @@ proxy:
       timeoutSeconds: 5
   affinity:
     anti_affinity: true
+    anti_affinity_topology_key: kubernetes.io/hostname
     # Set the anti affinity type. Valid values:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee


### PR DESCRIPTION
Adds the ability to configure anti-affinity topology key.

### Motivation

Ability to set custom anti-affinity topology key should make it easier to use pulsar-helm-charts in a high availability multi-AZ cluster (we can use zone/region topology key). Also custom topology will allow the use of keys that are non-standard/not-well-known (see https://kubernetes.io/docs/reference/labels-annotations-taints/), the example being "topology.ebs.csi.aws.com/zone`" from EBS (see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/729), or just being deprecated (like "failure-domain.beta.kubernetes.io/zone") but still used on older k8s clusters.

I realize there are already 2 PRs waiting for the acceptance that kind of do the same thing:
* https://github.com/apache/pulsar-helm-chart/pull/61 -- at this moment it is a bit stale as it was created in September 2020 (and there are more other changes/refactorings).
* https://github.com/apache/pulsar-helm-chart/pull/127 -- functionally very similar to this one (except soft affinity weight configuration) but does not allow to configure custom topology key. Being able to configure the topology key makes this PR simpler.

### Modifications

Just the ability to configure topology keys using new values: <component>.affinity.anti_affinity_topology_key -- defaults to currently hard-coded "kubernetes.io/hostname".

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
