### PR TITLE
Fix pod annotations when `restartPodsOnConfigMapChange` is true

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -41,7 +41,9 @@ spec:
         {{- if .Values.pulsar_manager.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/pulsar-manager-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{ toYaml .Values.pulsar_manager.annotations | indent 8 }}
+{{- with .Values.pulsar_manager.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
     {{- if .Values.pulsar_manager.nodeSelector }}
       nodeSelector:

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -45,7 +45,9 @@ spec:
         {{- if .Values.toolset.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/toolset-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{ toYaml .Values.toolset.annotations | indent 8 }}
+{{- with .Values.toolset.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
     {{- if .Values.toolset.nodeSelector }}
       nodeSelector:

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -46,7 +46,9 @@ spec:
         {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{ toYaml .Values.zookeeper.annotations | indent 8 }}
+{{- with .Values.zookeeper.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
     {{- if .Values.zookeeper.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
### Motivation

When `restartPodsOnConfigMapChange` is true, pod template such as:
```yaml
      annotations:
        {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
        checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
        {{- end }}
{{ toYaml .Values.zookeeper.annotations | indent 8 }}
```
will be generated to:
```yaml
      annotations:
        checksum/config: <sha256>
        {}
```
which is not a valid yaml

### Modifications

Geneate `.Values.<component>.annotations` only if is has values.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
