### PR TITLE
Improve HPA

### DIFF
--- a/charts/pulsar/templates/broker-hpa.yaml
+++ b/charts/pulsar/templates/broker-hpa.yaml
@@ -18,7 +18,11 @@
 #
 
 {{- if .Values.broker.autoscaling.enabled }}
+{{- if (semverCompare "<1.23-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -28,7 +28,9 @@ metadata:
     component: {{ .Values.broker.component }}
 spec:
   serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+  {{- if not .Values.broker.autoscaling.enabled }}
   replicas: {{ .Values.broker.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/templates/proxy-hpa.yaml
+++ b/charts/pulsar/templates/proxy-hpa.yaml
@@ -18,7 +18,11 @@
 #
 
 {{- if .Values.proxy.autoscaling.enabled }}
+{{- if (semverCompare "<1.23-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -28,7 +28,9 @@ metadata:
     component: {{ .Values.proxy.component }}
 spec:
   serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+  {{- if not .Values.proxy.autoscaling.enabled }}
   replicas: {{ .Values.proxy.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}


### PR DESCRIPTION
### Motivation

- Support Kubernetes 1.26 `warning "autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler"`
- Field `.spec.replicas` should be owned by `kube-controller-manager` when HPA is enabled

### Modifications

- Use `autoscaling/v2` if Kubernetes version >= 1.23
- When `.Values.<component>.autoscaling.enabled` is set to true, field `.spec.replicas` is not generated

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
