### PR TITLE
Changed `publishNotReadyAddresses` to service spec from annotation

### DIFF
--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -48,4 +48,7 @@ spec:
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
+  {{- if .Values.zookeeper.service.spec }}
+    {{- toYaml .Values.zookeeper.service.spec | trim | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -398,8 +398,8 @@ zookeeper:
   ## templates/zookeeper-service.yaml
   ##
   service:
-    annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    spec:
+      publishNotReadyAddresses: true
   ## Zookeeper PodDisruptionBudget
   ## templates/zookeeper-pdb.yaml
   ##


### PR DESCRIPTION
Same as apache#64 but for Zookeeper.

### Motivation

- `publishNotReadyAddresses` is a service spec and not a service annotation. This is mentioned in the K8s API docs at https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#servicespec-v1-core

### Modifications

- Modified `publishNotReadyAddresses` from annotation to service spec

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
