### PR TITLE
fix: proxy should not use priviledged port numbers

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -37,17 +37,21 @@ spec:
     - name: http
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
+      targetPort: sts-http
     - name: "{{ .Values.tcpPrefix }}pulsar"
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
+      targetPort: "sts-{{ .Values.tcpPrefix }}pulsar"
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
+      targetPort: sts-https
     - name: "{{ .Values.tlsPrefix }}pulsarssl"
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
+      targetPort: "sts-{{ .Values.tlsPrefix }}pulsarssl"
     {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -186,16 +186,16 @@ spec:
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
         # prometheus needs to access /metrics endpoint
-        - name: http
-          containerPort: {{ .Values.proxy.ports.http }}
+        - name: sts-http
+          containerPort: {{ .Values.proxy.ports.containerPorts.http }}
         {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
-        - name: "{{ .Values.tcpPrefix }}pulsar"
+        - name: "sts-{{ .Values.tcpPrefix }}pulsar"
           containerPort: {{ .Values.proxy.ports.pulsar }}
         {{- end }}
         {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
-        - name: https
-          containerPort: {{ .Values.proxy.ports.https }}
-        - name: "{{ .Values.tlsPrefix }}pulsarssl"
+        - name: sts-https
+          containerPort: {{ .Values.proxy.ports.containerPorts.https }}
+        - name: "sts-{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.proxy.ports.pulsarssl }}
         {{- end }}
       {{- if and .Values.rbac.enabled .Values.rbac.psp }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -900,10 +900,13 @@ proxy:
   ## templates/proxy-service.yaml
   ##
   ports:
-    http: 8080
-    https: 8443
+    http: 80
+    https: 443
     pulsar: 6650
     pulsarssl: 6651
+    containerPorts:
+      http: 8080
+      https: 8443
   service:
     annotations: {}
     type: LoadBalancer

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -900,8 +900,8 @@ proxy:
   ## templates/proxy-service.yaml
   ##
   ports:
-    http: 80
-    https: 443
+    http: 8080
+    https: 8443
     pulsar: 6650
     pulsarssl: 6651
   service:


### PR DESCRIPTION
This fixes issue #335

### Motivation

Fixing the port 80 binding issue in issue #335 

### Modifications

Changed from port 80 -> 8080 for HTTP and 443 -> 8443 for HTTPS

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
