### PR TITLE
add ingressClassName

### DIFF
--- a/charts/pulsar/templates/dashboard-ingress.yaml
+++ b/charts/pulsar/templates/dashboard-ingress.yaml
@@ -36,6 +36,9 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
+  {{- with .Values.dashboard.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
 {{- if .Values.dashboard.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -35,6 +35,9 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
+  {{- with .Values.proxy.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
 {{- if .Values.proxy.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -35,6 +35,9 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
+  {{- with .Values.pulsar_manager.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
 {{- if .Values.pulsar_manager.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -913,6 +913,7 @@ proxy:
   ingress:
     enabled: false
     annotations: {}
+    ingressClassName: ""
     tls:
       enabled: false
 
@@ -959,6 +960,7 @@ dashboard:
   ingress:
     enabled: false
     annotations: {}
+    ingressClassName: ""
     tls:
       enabled: false
 
@@ -1071,6 +1073,7 @@ pulsar_manager:
   ingress:
     enabled: false
     annotations: {}
+    ingressClassName: ""
     tls:
       enabled: false
 


### PR DESCRIPTION
Fixes #333 
### Motivation

We should be able to add ingressClassName to any of the ingress rules (pulsar-proxy,pulsar_manager and dashboard) and putting in the annotation as `kubernetes.io/ingress.class` was deprecated long time ago

### Modifications

I Added in: proxy-ingress, dashboard-ingress and pulsar-manager-ingress templates the support for `ingressClassName` together with adding `ingressClassName: ""` under each context in `values.yaml` 

### Verifying this change

- [x] Make sure that the change passes the CI checks.
