### PR TITLE
Test with Kubeadm 1.24.12

### DIFF
--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -83,7 +83,7 @@ done
 
 clusterName=${clusterName:-pulsar-dev}
 nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.18.19}
+k8sVersion=${k8sVersion:-v1.24.13}
 volumeNum=${volumeNum:-9}
 
 echo "clusterName: ${clusterName}"

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -37,10 +37,10 @@ Options:
        -h,--help               prints the usage message
        -n,--name               name of the Kubernetes cluster,default value: kind
        -c,--nodeNum            the count of the cluster nodes,default value: 6
-       -k,--k8sVersion         version of the Kubernetes cluster,default value: v1.12.8
+       -k,--k8sVersion         version of the Kubernetes cluster,default value: v1.24.12
        -v,--volumeNum          the volumes number of each kubernetes node,default value: 9
 Usage:
-    $0 --name testCluster --nodeNum 4 --k8sVersion v1.12.9
+    $0 --name testCluster --nodeNum 4 --k8sVersion v1.24.12
 EOF
 }
 
@@ -83,7 +83,7 @@ done
 
 clusterName=${clusterName:-pulsar-dev}
 nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.24.13}
+k8sVersion=${k8sVersion:-v1.24.12}
 volumeNum=${volumeNum:-9}
 
 echo "clusterName: ${clusterName}"


### PR DESCRIPTION
### Motivation

kubeadm failed to start in several recent tests. I noticed we're running with an old version of kubeadm. This PR upgrades to a more recent version. Specifically, the oldest one still getting patch support from the upstream Kubernetes project.

### Modifications

Update the test script.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
