### PR TITLE
Update appVersion to "3.0.0" in Chart.yaml

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "2.10.2"
+appVersion: "3.0.0"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.0.0


### PR DESCRIPTION
Fixes #364 

### Motivation

*Pulsar Helm chart still installs version 2.10.2. Bump version so 3.0.0 is installed*

### Modifications

*Modified the chart.yaml file. *

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
