### PR TITLE
Replace removed tolerate-unready-endpoints annotation with publishNotReadyAddresses

### DIFF
--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -45,6 +45,7 @@ spec:
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -398,8 +398,7 @@ zookeeper:
   ## templates/zookeeper-service.yaml
   ##
   service:
-    annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    annotations: {}
   ## Zookeeper PodDisruptionBudget
   ## templates/zookeeper-pdb.yaml
   ##


### PR DESCRIPTION
### Motivation

Pulsar helm chart isn't compatible with k8s 1.24+ since there isn't a way to configure Zookeeper service with `publishNotReadyAddresses: true`.
- `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation was removed in k8s 1.24 with commit https://github.com/kubernetes/kubernetes/commit/ae9f1173870822c186a1ddd696835cc5a9b989ec

### Modifications

- set `publishNotReadyAddresses: true` for zookeeper service
- remove traces of removed `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
