### PR TITLE
Enables Nodeport Support For the Proxy Service

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -38,20 +38,40 @@ spec:
       port: {{ .Values.proxy.ports.http }}
       protocol: TCP
       targetPort: sts-http
+      {{- if and (eq .Values.service.type "NodePort") (ne .Values.service.nodePorts.http "") }}
+        nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else}}
+        nodePort: null
+      {{- end}}
     - name: "{{ .Values.tcpPrefix }}pulsar"
       port: {{ .Values.proxy.ports.pulsar }}
       protocol: TCP
       targetPort: "sts-{{ .Values.tcpPrefix }}pulsar"
+      {{- if and (eq .Values.service.type "NodePort") (ne .Values.service.nodePorts.pulsar "") }}
+        nodePort: {{ .Values.service.nodePorts.pulsar }}
+      {{- else}}
+        nodePort: null
+      {{- end}}
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.https }}
       protocol: TCP
       targetPort: sts-https
+      {{- if and (eq .Values.service.type "NodePort") (ne .Values.service.nodePorts.https "") }}
+        nodePort: {{ .Values.service.nodePorts.https }}
+      {{- else}}
+        nodePort: null
+      {{- end}}
     - name: "{{ .Values.tlsPrefix }}pulsarssl"
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
       targetPort: "sts-{{ .Values.tlsPrefix }}pulsarssl"
+      {{- if and (eq .Values.service.type "NodePort") (ne .Values.service.nodePorts.pulsarssl "") }}
+        nodePort: {{ .Values.service.nodePorts.pulsarssl }}
+      {{- else}}
+        nodePort: null
+      {{- end}}
     {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -917,6 +917,12 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
+    nodePorts:
+      http: ""
+      https: ""
+      pulsar: ""
+      pulsarssl: ""
+    
   ## Proxy ingress
   ## templates/proxy-ingress.yaml
   ##


### PR DESCRIPTION
Adds optional NodePort Support for the proxy service

# Motivation
When creating local kube clusters there are times where nodeports become more useful and easier to setup for testing than setting up the load balancer.

# Modifications
Optional nodeport options were added for the http, https, pulsar, and pulsarssl services via the proxy

# Verifying this change
- [x] Make sure that the change passes the CI checks.
