### PR TITLE
docs: Update README to reflect unmaintained status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@
     under the License.
 
 -->
-# Official Apache Pulsar Helm Chart
 
-This is the officially supported Helm Chart for installing Apache Pulsar on Kubernetes.
+# Apache Pulsar Helm Chart
+
+This project provides Helm Charts for installing Apache Pulsar on Kubernetes.
 
 Read [Deploying Pulsar on Kubernetes](http://pulsar.apache.org/docs/deploy-kubernetes/) for more details.
+
+> :warning: This helm chart is updated outside of the regular Pulsar release cycle and might lag behind a bit. It only supports basic Kubernetes features now. Currently, it can be used as no more than a template and starting point for a Kubernetes deployment. In many cases, it would require some customizations.
 
 ## Features
 


### PR DESCRIPTION
This picks up https://github.com/apache/pulsar-helm-chart/pull/367.

See the discussion on the list at https://lists.apache.org/thread/zrqs973cbvm7szs8kktgbgfohs8gdrzp.

Specially, I wrote:

> I totally appreciate anyone who is willing to maintain the pulsar-helm-chart, but let's do not block the description updates by such an argument. Instead, update the description, and change it back when the development and maintenance really happen. It also reflects the low traffic during the past few years.