### PR TITLE
Initialize Pulsar cluster with Proxy config 

### DIFF
--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -105,6 +105,12 @@ spec:
               {{- if not .Values.pulsar_metadata.configurationStore }}
               --configuration-store {{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }} \
               {{- end }}
+              {{- if not .Values.pulsar_metadata.proxyUrl }}
+              --proxy-url {{ .Values.pulsar_metadata.proxyUrl }} \
+              {{- end }}
+              {{- if not .Values.pulsar_metadata.proxyProtocol }}
+              --proxy-protocol {{ .Values.pulsar_metadata.proxyProtocol }} \
+              {{- end }}
               --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.http }}/ \
               --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.https }}/ \
               --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.broker.ports.pulsar }}/ \


### PR DESCRIPTION

### Motivation

We need to update Pulsar cluster metadata with ProxyUrl while using ATS proxy. So, support Pulsar-cluster-metadata-init with proxy config

### Modifications

Add proxy-url and proxy-protocol values in Pulsar-cluster-metadata-init

### Verifying this change

- [x] Make sure that the change passes the CI checks.
