### PR TITLE
Fixed bookkeeper volume mounts indentation

### DIFF
--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -189,8 +189,8 @@ spec:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         volumeMounts:
         {{- if .Values.bookkeeper.volumes.useSingleCommonVolume }}
-          - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
-            mountPath: /pulsar/data/bookkeeper
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.common.name }}"
+          mountPath: /pulsar/data/bookkeeper
         {{- else }}
           {{- if .Values.bookkeeper.volumes.journal.useMultiVolumes }}
             {{- $fullname := include "pulsar.fullname" . -}}


### PR DESCRIPTION
Fixed bookkeeper volume mounts indentation. Volume mount created by setting useSingleCommonVolume parameter to true had indentation 10 and should have 8 like rest of volume mounts.

Fixes #379

### Motivation
I couldn't add extra volume mount with log4j2 config because of the issue. 
