### PR TITLE
fix backend boot failure

### DIFF
--- a/examples/values-minikube.yaml
+++ b/examples/values-minikube.yaml
@@ -49,3 +49,9 @@ broker:
 
 proxy:
   replicaCount: 1
+
+pulsar_manager:
+  configData:
+    ENV_SPRING_CONFIGURATION_FILE: "/pulsar-manager/pulsar-manager/application.properties"
+    SPRING_CONFIGURATION_FILE: "/pulsar-manager/pulsar-manager/application.properties"
+    PULSAR_MANAGER_OPTS: " -Dlog4j2.formatMsgNoLookups=true"


### PR DESCRIPTION
Fixes #505

### Motivation

Using the default settings of the Pulsar Helm Chart to run Pulsar Manager results in a non-functional manager instance. This PR suggests a fix.

### Modifications

Fix `examples/values-minikube.yml` as suggested [here](https://github.com/apache/pulsar-manager/issues/505#issuecomment-1606947653) by @jesperbagge

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
