### PR TITLE
Lowered BOOKIE_MEM and PULSAR_MEM in init containers

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -49,8 +49,6 @@ spec:
         args:
           - >-
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
-            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export PULSAR_MEM="-Xmx128M";
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
               echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
@@ -73,8 +71,6 @@ spec:
           - >
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
-            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export BOOKIE_MEM="-Xmx128M";
             if bin/bookkeeper shell whatisinstanceid; then
                 echo "bookkeeper cluster already initialized";

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -49,6 +49,9 @@ spec:
         args:
           - >-
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
+            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export PULSAR_MEM="-Xmx128M";
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
               echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
             done;
@@ -70,6 +73,9 @@ spec:
           - >
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
+            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export BOOKIE_MEM="-Xmx128M";
             if bin/bookkeeper shell whatisinstanceid; then
                 echo "bookkeeper cluster already initialized";
             else

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -114,6 +114,9 @@ spec:
         args:
           - >-
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
+            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export BOOKIE_MEM="-Xmx128M";
             {{- if .Values.pulsar_metadata.configurationStore }}
             until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.configurationStore.connect" . }} get {{ .Values.configurationStoreMetadataPrefix }}/admin/clusters/{{ template "pulsar.cluster.name" . }}; do
             {{- end }}
@@ -138,6 +141,9 @@ spec:
           - >
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             bin/apply-config-from-env.py conf/bookkeeper.conf;
+            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export BOOKIE_MEM="-Xmx128M";
             until bin/bookkeeper shell whatisinstanceid; do
               echo "bookkeeper cluster is not initialized yet. backoff for 3 seconds ...";
               sleep 3;

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -114,8 +114,6 @@ spec:
         args:
           - >-
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
-            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export BOOKIE_MEM="-Xmx128M";
             {{- if .Values.pulsar_metadata.configurationStore }}
             until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.configurationStore.connect" . }} get {{ .Values.configurationStoreMetadataPrefix }}/admin/clusters/{{ template "pulsar.cluster.name" . }}; do
@@ -141,8 +139,6 @@ spec:
           - >
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             bin/apply-config-from-env.py conf/bookkeeper.conf;
-            echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export BOOKIE_MEM="-Xmx128M";
             until bin/bookkeeper shell whatisinstanceid; do
               echo "bookkeeper cluster is not initialized yet. backoff for 3 seconds ...";

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -115,8 +115,6 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export PULSAR_MEM="-Xmx128M";
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -115,6 +115,9 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
+            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export PULSAR_MEM="-Xmx128M";
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
               echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -58,8 +58,6 @@ spec:
         args:
           - >-
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
-            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export PULSAR_MEM="-Xmx128M";
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
               echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
@@ -102,8 +100,6 @@ spec:
         args:
           - |
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
-            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
-            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
             export PULSAR_MEM="-Xmx128M";
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.cluster.name" . }} \

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -58,6 +58,9 @@ spec:
         args:
           - >-
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
+            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export PULSAR_MEM="-Xmx128M";
             until bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
               echo "user provided zookeepers {{ $zk }} are unreachable... check in 3 seconds ..." && sleep 3;
             done;
@@ -75,6 +78,9 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
+          echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
+          echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+          export BOOKIE_MEM="-Xmx128M";
           {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 10 }}
           until bin/bookkeeper shell whatisinstanceid; do
             sleep 3;
@@ -96,6 +102,9 @@ spec:
         args:
           - |
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
+            echo Default PULSAR_MEM settings are set very high, which can cause the init container to fail.;
+            echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;
+            export PULSAR_MEM="-Xmx128M";
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.cluster.name" . }} \
               --zookeeper {{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }} \


### PR DESCRIPTION
Lowered BOOKIE_MEM and PULSAR_MEM in init containers 
Default BOOKIE_MEM and PULSAR_MEM settings from conf/pulsar_env.sh and conf/bkenv.sh (-Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g) are too high for low-memory systems.

Fixes #373

### Motivation
I saw OOM errors when initializing cluster on our low-memory node, especially in pulsar-pulsar-init job. 

### Modifications
I've added custom PULSAR_MEM and BOOKIE_MEM settings to init containers to places where bookkeeper / pulsar shell commands are run, and there shouldn't be much memory needed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
