### PR TITLE
Allow Proxy and Broker HPA to specify scaling policies on scaleUp or …

### DIFF
--- a/charts/pulsar/templates/broker-hpa.yaml
+++ b/charts/pulsar/templates/broker-hpa.yaml
@@ -33,6 +33,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   minReplicas: {{ .Values.broker.autoscaling.minReplicas }}
+  {{- with .Values.broker.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/charts/pulsar/templates/proxy-hpa.yaml
+++ b/charts/pulsar/templates/proxy-hpa.yaml
@@ -33,6 +33,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   minReplicas: {{ .Values.proxy.autoscaling.minReplicas }}
+  {{- with .Values.proxy.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -684,6 +684,7 @@ broker:
     minReplicas: 1
     maxReplicas: 3
     metrics: ~
+    behavior: ~
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -818,6 +819,7 @@ proxy:
     minReplicas: 1
     maxReplicas: 3
     metrics: ~
+    behavior: ~
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true


### PR DESCRIPTION
…scaleDown.

### Motivation

While testing Pulsar Broker autoscaling we found that during a scale-down event (going from 14 brokers to 2 in the space of about 15 minutes) that namespace bundle movement occurred very frequently and we would like to slow the rate at which the brokers scale down using Scaling Policies.

See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior for more details

We would also like to use the `stabilizationWindowSeconds` to ensure that if/when we add brokers we don't suddenly scale-down soon after (sometimes CPU spikes can occur as brokers die, new brokers launch and that can result in a temporary spike in average broker CPU causing scale-up. When the spike fades then it may cause a scale-down resulting in namespace bundles moving yet again).

### Modifications

Provide hooks in the `hpa` helm chart templates to provide behaviors e.g. 

```
behavior:
  scaleDown:
    stabilizationWindowSeconds: 600
    policies:
    - type: Pods
      value: 1
      periodSeconds: 60
```

### Example Usage
From local minikube

Definition
```
broker: 
.
.
      autoscaling:
        enabled: true
        minReplicas: 1
        maxReplicas: 3
        behavior:
          scaleDown:
            stabilizationWindowSeconds: 180
            policies:
            - type: Pods
              value: 1
              periodSeconds: 300
        metrics:
        - type: Resource
          resource:
            name: cpu
            target:
              type: Utilization
              averageUtilization: 60
```
HPA shows up as 
```
$ kubectl describe hpa pulsar-broker
Name:                                                  pulsar-broker
Namespace:                                             cogito
Labels:                                                app.kubernetes.io/managed-by=Helm
Annotations:                                           meta.helm.sh/release-name: pulsar
                                                       meta.helm.sh/release-namespace: cogito
CreationTimestamp:                                     Wed, 06 Sep 2023 12:04:44 -0400
Reference:                                             StatefulSet/pulsar-broker
Metrics:                                               ( current / target )
  resource cpu on pods  (as a percentage of request):  12% (32m) / 60%
Min replicas:                                          1
Max replicas:                                          3
Behavior:
  Scale Up:
    Stabilization Window: 0 seconds
    Select Policy: Max
    Policies:
      - Type: Pods     Value: 4    Period: 15 seconds
      - Type: Percent  Value: 100  Period: 15 seconds
  Scale Down:
    Stabilization Window: 180 seconds
    Select Policy: Max
    Policies:
      - Type: Pods  Value: 1  Period: 300 seconds
StatefulSet pods:   1 current / 1 desired
Conditions:
  Type            Status  Reason              Message
  ----            ------  ------              -------
  AbleToScale     True    ReadyForNewScale    recommended size matches current size
  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)
  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
```

NOTE: Tested in Minikube via
* Ensure Metrics Server is enabled `minikube addons enable metrics-server`
* Keda autoscaler enabled
```
kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.8.2/keda-2.8.2.yaml
```

and we can inspect it in operation using
```
8m31s       Normal    SuccessfulRescale              horizontalpodautoscaler/pulsar-broker                                 New size: 3; reason: cpu resource utilization (percentage of request) above target
19m         Normal    SuccessfulCreate               statefulset/pulsar-broker                                             create Pod pulsar-broker-1 in StatefulSet pulsar-broker successful
8m31s       Normal    SuccessfulCreate               statefulset/pulsar-broker                                             create Pod pulsar-broker-2 in StatefulSet pulsar-broker successful
12m         Normal    SuccessfulRescale              horizontalpodautoscaler/pulsar-broker                                 New size: 2; reason: All metrics below target
12m         Normal    SuccessfulDelete               statefulset/pulsar-broker                                             delete Pod pulsar-broker-2 in StatefulSet pulsar-broker successful
44m         Normal    Created                        pod/pulsar-proxy-0                                                    Created container wait-broker-ready
44m         Normal    Started                        pod/pulsar-proxy-0                                                    Started container wait-broker-ready
33m         Normal    Created                        pod/pulsar-proxy-0                                                    Created container wait-broker-ready
33m         Normal    Started                        pod/pulsar-proxy-0                                                    Started container wait-broker-ready
3m38s       Normal    Created                        pod/pulsar-proxy-1                                                    Created container wait-broker-ready
3m37s       Normal    Started                        pod/pulsar-proxy-1                                                    Started container wait-broker-ready
0s          Normal    SuccessfulRescale              horizontalpodautoscaler/pulsar-broker                                 New size: 2; reason: All metrics below target
0s          Normal    SuccessfulDelete               statefulset/pulsar-broker                                             delete Pod pulsar-broker-2 in StatefulSet pulsar-broker successful
0s          Normal    Killing                        pod/pulsar-broker-2                                                   Stopping container pulsar-broker
```


### Verifying this change

- [ ] Make sure that the change passes the CI checks.
