### PR TITLE
Add function config values to function-worker-configmap.yaml

### DIFF
--- a/charts/pulsar/templates/function-worker-configmap.yaml
+++ b/charts/pulsar/templates/function-worker-configmap.yaml
@@ -29,4 +29,6 @@ metadata:
     component: {{ .Values.functions.component }}
 data:
   pulsarDockerImageName: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.functions "root" .) }}"
+{{ toYaml .Values.functions | indent 2 }}
+
 {{- end }}


### PR DESCRIPTION
Previously config values for function were not being added to the K8s configmap even if they were set in the values.yaml under the functions section.

### Motivation
I have been unable to configure Pulsar functions via the values.yaml( E.g. configuring runtimeCustomizerClassName) .
The values I set do not appear in the configmap that is generated by Helm in K8s, and therefore the changes are not reflected in Pulsar.

### Modifications

I have changed the template for the function-worker-configmap.yaml so that it will add the correct config values to the k8s configmap.
