### PR TITLE
feat: added support for tolerations for the init jobs

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -41,6 +41,10 @@ spec:
       {{- if .Values.pulsar_metadata.nodeSelector }}
 {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}
+      tolerations:
+      {{- if .Values.pulsar_metadata.tolerations }}
+{{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
+      {{- end }}
       initContainers:
       - name: wait-zookeeper-ready
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.bookie "root" .) }}"

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -121,5 +121,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.pulsar_metadata.tolerations }}
+      tolerations:
+{{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -656,17 +656,20 @@ pulsar_metadata:
   # configurationStore:
   configurationStoreMetadataPrefix: ""
   configurationStorePort: 2181
-  ## optional you can specify a nodeSelector for all init jobs (pulsar-init & bookkeeper-init)
-  # nodeSelector:
-    # cloud.google.com/gke-nodepool: default-pool
+
+  ## optional you can specify tolerations and nodeSelectors for all init jobs (pulsar-init & bookkeeper-init)
+  #tolerations: []
+  #  - key: "someKey"
+  #    operator: "Equal"
+  #    value: "someValue"
+  #    effect: "NoSchedule"
+  #nodeSelector: {}
+  #  cloud.google.com/gke-nodepool: default-pool
 
   ## optional, you can provide your own zookeeper metadata store for other components
   # to use this, you should explicit set components.zookeeper to false
   #
   # userProvidedZookeepers: "zk01.example.com:2181,zk02.example.com:2181"
-
-  ## optional, you can specify where to run pulsar-cluster-initialize job
-  # nodeSelector:
 
 # Can be used to run extra commands in the initialization jobs e.g. to quit istio sidecars etc.
 extraInitCommand: ""


### PR DESCRIPTION
Fixes #398 

### Motivation

Adding support for the init jobs to have tolerations as well along with nodeSelectors.

### Modifications

Adding tolerations field to the init job templates.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
