### PR TITLE
feat: add externalTrafficPolicy and loadBalancerSourceRanges

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -32,6 +32,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.proxy.service.type }}
+  {{- if .Values.proxy.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.proxy.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.proxy.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.proxy.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
     - name: http

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -30,6 +30,12 @@ metadata:
 {{ toYaml .Values.pulsar_manager.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.pulsar_manager.service.type }}
+  {{- if .Values.pulsar_manager.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.pulsar_manager.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.pulsar_manager.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - name: server
       port: {{ .Values.pulsar_manager.service.port }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -919,6 +919,11 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
+    ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    # externalTrafficPolicy: 
+    loadBalancerSourceRanges:
+    - a.b.c.d/32
   ## Proxy ingress
   ## templates/proxy-ingress.yaml
   ##
@@ -1079,6 +1084,11 @@ pulsar_manager:
     port: 9527
     targetPort: 9527
     annotations: {}
+    ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    # externalTrafficPolicy: 
+    loadBalancerSourceRanges:
+    - a.b.c.d/32
   ## Pulsar manager ingress
   ## templates/pulsar-manager-ingress.yaml
   ##


### PR DESCRIPTION
Fixes #externalTrafficPolicy&loadBalancerSourceRanges

### Motivation

With LoadBalancer service we want get clientIp so we need externalTrafficPolicy and also we want autorize ip to access to loadbalancer

### Modifications

add externalTrafficPolicy and loadBalancerSourceRanges in proxy-service and pulsar-manager-service

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
