### PR TITLE
feat: add metricsRelabelings on podMonitor

### DIFF
--- a/charts/pulsar/templates/autorecovery-podmonitor.yaml
+++ b/charts/pulsar/templates/autorecovery-podmonitor.yaml
@@ -48,6 +48,9 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_name]
           action: replace
           targetLabel: kubernetes_pod_name
+    {{- if $.Values.autorecovery.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.autorecovery.podMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/templates/bookkeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/bookkeeper-podmonitor.yaml
@@ -48,6 +48,9 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_name]
           action: replace
           targetLabel: kubernetes_pod_name
+    {{- if $.Values.bookkeeper.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.bookkeeper.podMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/templates/broker-podmonitor.yaml
+++ b/charts/pulsar/templates/broker-podmonitor.yaml
@@ -48,6 +48,9 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_name]
           action: replace
           targetLabel: kubernetes_pod_name
+    {{- if $.Values.broker.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.broker.podMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/templates/proxy-podmonitor.yaml
+++ b/charts/pulsar/templates/proxy-podmonitor.yaml
@@ -48,6 +48,9 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_name]
           action: replace
           targetLabel: kubernetes_pod_name
+    {{- if $.Values.proxy.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.proxy.podMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/templates/zookeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/zookeeper-podmonitor.yaml
@@ -48,6 +48,9 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_name]
           action: replace
           targetLabel: kubernetes_pod_name
+    {{- if $.Values.zookeeper.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml $.Values.zookeeper.podMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -290,6 +290,9 @@ zookeeper:
     enabled: true
     interval: 10s
     scrapeTimeout: 10s
+    metricRelabelings:
+      # - action: labeldrop
+      #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   ports:
@@ -432,6 +435,9 @@ bookkeeper:
     enabled: true
     interval: 10s
     scrapeTimeout: 10s
+    metricRelabelings:
+      # - action: labeldrop
+      #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   ports:
@@ -610,6 +616,9 @@ autorecovery:
     enabled: true
     interval: 10s
     scrapeTimeout: 10s
+    metricRelabelings:
+      # - action: labeldrop
+      #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   ports:
@@ -690,6 +699,9 @@ broker:
     enabled: true
     interval: 10s
     scrapeTimeout: 10s
+    metricRelabelings:
+      # - action: labeldrop
+      #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   ports:
@@ -825,6 +837,9 @@ proxy:
     enabled: true
     interval: 10s
     scrapeTimeout: 10s
+    metricRelabelings:
+      # - action: labeldrop
+      #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   # nodeSelector:


### PR DESCRIPTION
Fixes #metricsRelabelings

### Motivation

We want drop cluster label in metrics and we don't use it in our prometheus stack because we have one datasource by pulsar metrics. Because we use this label only for our remoteWrite config on mimir side for push tenant metrics

### Modifications

I have only add metricRelabelings field on all podMonitor

### Verifying this change

- [x] Make sure that the change passes the CI checks.
