### PR TITLE
Support multiple hostnames in ingress definitions

### DIFF
--- a/charts/pulsar/templates/dashboard-ingress-new.yaml
+++ b/charts/pulsar/templates/dashboard-ingress-new.yaml
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+{{- if and .Values.dashboard.ingress.enabled .Values.dashboard.ingress.hosts }}
+{{- $fullname := include "pulsar.fullname" . -}}
+
+{{- /* To assist in configuring TLS this Ingress provides the ability to dynamically */ -}}
+{{- /* configure the TLS spec based off of host configurations should a TLS spec not be provided. */ -}}
+
+{{- $tlsData := dict -}}
+
+{{- /* Build a TLS secret to host lookup */ -}}
+{{- range $i, $host := .Values.dashboard.ingress.hosts -}}
+  {{- $hostTLS := $host.tls | default dict -}}
+  {{- $hostTLSEnabled := $hostTLS.enabled | default true -}}
+  {{- if $hostTLSEnabled }}
+    {{- /* Generate secret name */ -}}
+    {{- $hostTLSSecretName := print "pulsar-" $.Values.dashboard.component "-" $hostTLS.secretName "-tls" -}}
+    {{- /* Default to an empty list */ -}}
+    {{- $tlsSecretHosts := list -}}
+    {{- /* Get the host list if we have seen the secret before */ -}}
+    {{- if hasKey $tlsData $hostTLSSecretName }}
+      {{- $tlsSecretHosts = get $tlsData $hostTLSSecretName -}}
+    {{- end }}
+    {{- /* Add the host to the list */ -}}
+    {{- $tlsSecretHosts = append $tlsSecretHosts $host.host -}}
+    {{- /* Update the list of hosts in the dict */ -}}
+    {{- $tlsData = set $tlsData $hostTLSSecretName $tlsSecretHosts -}}
+  {{- end }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+{{- /* global annotations */ -}}
+{{- with .Values.dashboard.ingress.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.dashboard.component }}
+  name: "{{ $fullname }}-{{ .Values.dashboard.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+spec:
+  {{- with .Values.dashboard.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- /* Iterate over the list of hosts */ -}}
+    {{- range $i, $host := .Values.dashboard.ingress.hosts }}
+    {{- $excludePaths := ($host.excludePaths | default list) }}
+    {{- $includePaths := ($host.includePaths | default list) }}
+    - host: {{ $host.host }}
+      http:
+        paths:
+        {{- /* Iterate over the list of paths */ -}}
+        {{- range $pathName, $path := $.Values.dashboard.ingress.paths -}}
+        {{- /* A path is included explicitly if the includePaths is empty or the is path is present within the includedPaths */ -}}
+        {{- $isIncluded := or (empty $host.includePaths) (has $pathName $host.includePaths) }}
+        {{- /* A path is excluded explicitly if the path is present within the excludedPaths  */ -}}
+        {{- $isExcluded := or (not (empty $host.excludePaths)) (has $pathName $host.excludePaths) }}
+        {{- /* If the path is included and not excluded create an ingress object specifically for the path */ -}}
+        {{- if and $isIncluded (not $isExcluded) }}
+          - path: {{ $path.path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ $fullname }}-{{ $.Values.dashboard.component }}"
+                port:
+                  number: {{ $.Values.dashboard.ingress.port }}
+        {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.dashboard.ingress.tls.enabled }}
+  tls:
+    {{- range $tlsSecretName, $tlsHosts := $tlsData }}
+    - hosts:
+      {{- range $tlsHosts }}
+      - {{ . }}
+      {{- end }}
+      secretName: {{ $tlsSecretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/dashboard-ingress.yaml
+++ b/charts/pulsar/templates/dashboard-ingress.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.extra.dashboard }}
-{{- if .Values.dashboard.ingress.enabled }}
+{{- if and .Values.dashboard.ingress.enabled .Values.dashboard.ingress.hostname }}
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}

--- a/charts/pulsar/templates/proxy-ingress-new.yaml
+++ b/charts/pulsar/templates/proxy-ingress-new.yaml
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+{{- if and .Values.proxy.ingress.enabled .Values.proxy.ingress.hosts }}
+{{- $fullname := include "pulsar.fullname" . -}}
+
+{{- /* To assist in configuring TLS this Ingress provides the ability to dynamically */ -}}
+{{- /* configure the TLS spec based off of host configurations should a TLS spec not be provided. */ -}}
+
+{{- $tlsData := dict -}}
+
+{{- /* Build a TLS secret to host lookup */ -}}
+{{- range $i, $host := .Values.proxy.ingress.hosts -}}
+  {{- $hostTLS := $host.tls | default dict -}}
+  {{- $hostTLSEnabled := $hostTLS.enabled | default true -}}
+  {{- if $hostTLSEnabled }}
+    {{- /* Generate secret name */ -}}
+    {{- $hostTLSSecretName := print "pulsar-" $.Values.proxy.component "-" $hostTLS.secretName "-tls" -}}
+    {{- /* Default to an empty list */ -}}
+    {{- $tlsSecretHosts := list -}}
+    {{- /* Get the host list if we have seen the secret before */ -}}
+    {{- if hasKey $tlsData $hostTLSSecretName }}
+      {{- $tlsSecretHosts = get $tlsData $hostTLSSecretName -}}
+    {{- end }}
+    {{- /* Add the host to the list */ -}}
+    {{- $tlsSecretHosts = append $tlsSecretHosts $host.host -}}
+    {{- /* Update the list of hosts in the dict */ -}}
+    {{- $tlsData = set $tlsData $hostTLSSecretName $tlsSecretHosts -}}
+  {{- end }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+{{- /* global annotations */ -}}
+{{- with .Values.proxy.ingress.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.proxy.component }}
+  name: "{{ $fullname }}-{{ .Values.proxy.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+spec:
+  {{- with .Values.proxy.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- /* Iterate over the list of hosts */ -}}
+    {{- range $i, $host := .Values.proxy.ingress.hosts }}
+    {{- $excludePaths := ($host.excludePaths | default list) }}
+    {{- $includePaths := ($host.includePaths | default list) }}
+    - host: {{ $host.host }}
+      http:
+        paths:
+        {{- /* Iterate over the list of paths */ -}}
+        {{- range $pathName, $path := $.Values.proxy.ingress.paths -}}
+        {{- /* A path is included explicitly if the includePaths is empty or the is path is present within the includedPaths */ -}}
+        {{- $isIncluded := or (empty $host.includePaths) (has $pathName $host.includePaths) }}
+        {{- /* A path is excluded explicitly if the path is present within the excludedPaths  */ -}}
+        {{- $isExcluded := or (not (empty $host.excludePaths)) (has $pathName $host.excludePaths) }}
+        {{- /* If the path is included and not excluded create an ingress object specifically for the path */ -}}
+        {{- if and $isIncluded (not $isExcluded) }}
+          - path: {{ $path.path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ $fullname }}-{{ $.Values.proxy.component }}"
+                {{- if and $.Values.tls.enabled $.Values.tls.proxy.enabled }}
+                port:
+                  number: {{ $.Values.proxy.ports.https }}
+                {{- else }}
+                port:
+                  number: {{ $.Values.proxy.ports.http }}
+                {{- end }}
+        {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.tls.proxy.enabled }}
+  tls:
+    {{- range $tlsSecretName, $tlsHosts := $tlsData }}
+    - hosts:
+      {{- range $tlsHosts }}
+      - {{ . }}
+      {{- end }}
+      secretName: {{ $tlsSecretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.proxy.ingress.enabled }}
+{{- if and .Values.proxy.ingress.enabled .Values.proxy.ingress.hostname }}
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}
@@ -73,4 +73,4 @@ spec:
       {{- if .Values.proxy.ingress.hostname }}
       host: {{ .Values.proxy.ingress.hostname }}
       {{- end }}
-{{- end }}
+{{- end }} # End if ingress enabled 

--- a/charts/pulsar/templates/pulsar-manager-ingress-new.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress-new.yaml
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+{{- if and .Values.pulsar_manager.ingress.enabled .Values.pulsar_manager.ingress.hosts }}
+{{- $fullname := include "pulsar.fullname" . -}}
+
+{{- /* To assist in configuring TLS this Ingress provides the ability to dynamically */ -}}
+{{- /* configure the TLS spec based off of host configurations should a TLS spec not be provided. */ -}}
+
+{{- $tlsData := dict -}}
+
+{{- /* Build a TLS secret to host lookup */ -}}
+{{- range $i, $host := .Values.pulsar_manager.ingress.hosts -}}
+  {{- $hostTLS := $host.tls | default dict -}}
+  {{- $hostTLSEnabled := $hostTLS.enabled | default true -}}
+  {{- if $hostTLSEnabled }}
+    {{- /* Generate secret name */ -}}
+    {{- $hostTLSSecretName := print "pulsar-" $.Values.pulsar_manager.component "-" $hostTLS.secretName "-tls" -}}
+    {{- /* Default to an empty list */ -}}
+    {{- $tlsSecretHosts := list -}}
+    {{- /* Get the host list if we have seen the secret before */ -}}
+    {{- if hasKey $tlsData $hostTLSSecretName }}
+      {{- $tlsSecretHosts = get $tlsData $hostTLSSecretName -}}
+    {{- end }}
+    {{- /* Add the host to the list */ -}}
+    {{- $tlsSecretHosts = append $tlsSecretHosts $host.host -}}
+    {{- /* Update the list of hosts in the dict */ -}}
+    {{- $tlsData = set $tlsData $hostTLSSecretName $tlsSecretHosts -}}
+  {{- end }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+{{- /* global annotations */ -}}
+{{- with .Values.pulsar_manager.ingress.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.pulsar_manager.component }}
+  name: "{{ $fullname }}-{{ .Values.pulsar_manager.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+spec:
+  {{- with .Values.pulsar_manager.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- /* Iterate over the list of hosts */ -}}
+    {{- range $i, $host := .Values.pulsar_manager.ingress.hosts }}
+    {{- $excludePaths := ($host.excludePaths | default list) }}
+    {{- $includePaths := ($host.includePaths | default list) }}
+    - host: {{ $host.host }}
+      http:
+        paths:
+        {{- /* Iterate over the list of paths */ -}}
+        {{- range $pathName, $path := $.Values.pulsar_manager.ingress.paths -}}
+        {{- /* A path is included explicitly if the includePaths is empty or the is path is present within the includedPaths */ -}}
+        {{- $isIncluded := or (empty $host.includePaths) (has $pathName $host.includePaths) }}
+        {{- /* A path is excluded explicitly if the path is present within the excludedPaths  */ -}}
+        {{- $isExcluded := or (not (empty $host.excludePaths)) (has $pathName $host.excludePaths) }}
+        {{- /* If the path is included and not excluded create an ingress object specifically for the path */ -}}
+        {{- if and $isIncluded (not $isExcluded) }}
+          - path: {{ $path.path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ $fullname }}-{{ $.Values.pulsar_manager.component }}"
+                port:
+                  number: {{ $.Values.pulsar_manager.service.targetPort }}
+        {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.tls.pulsar_manager.enabled }}
+  tls:
+    {{- range $tlsSecretName, $tlsHosts := $tlsData }}
+    - hosts:
+      {{- range $tlsHosts }}
+      - {{ . }}
+      {{- end }}
+      secretName: {{ $tlsSecretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.pulsar_manager.ingress.enabled }}
+{{- if and .Values.pulsar_manager.ingress.enabled .Values.pulsar_manager.ingress.hostname }}
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
 {{- else }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -932,8 +932,20 @@ proxy:
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
 
+    # Deprecated Approach - only one host/path supported
     hostname: ""
     path: "/"
+    # New approach - multiple hosts supported
+    hosts: []
+    # - host: foo.bar.com
+    #   excludePaths: []
+    #   includePaths: []
+    #   tls:
+    #     enabled: true
+    #     secretName:
+    paths:
+      root:
+        path: /
   ## Proxy PodDisruptionBudget
   ## templates/proxy-pdb.yaml
   ##
@@ -979,9 +991,21 @@ dashboard:
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
 
+    # Deprecated Approach - only one host/path supported
     ## Required if ingress is enabled
     hostname: ""
     path: "/"
+    # New approach - multiple hosts supported
+    hosts: []
+    # - host: foo.bar.com
+    #   excludePaths: []
+    #   includePaths: []
+    #   tls:
+    #     enabled: true
+    #     secretName:
+    paths:
+      root:
+        path: /
     port: 80
 
 
@@ -1092,8 +1116,20 @@ pulsar_manager:
       ## Optional. Leave it blank if your Ingress Controller can provide a default certificate.
       secretName: ""
 
+    # Deprecated Approach - only one host/path supported
     hostname: ""
     path: "/"
+    # New approach - multiple hosts supported
+    hosts: []
+    # - host: foo.bar.com
+    #   excludePaths: []
+    #   includePaths: []
+    #   tls:
+    #     enabled: true
+    #     secretName:
+    paths:
+      root:
+        path: /
 
   ## If set use existing secret with specified name to set pulsar admin credentials.
   existingSecretName:


### PR DESCRIPTION
### Motivation

* Kubernetes Ingress definitions allow multiple DNS hostnames - see https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting for examples
  
### Modifications

* Because the number of changes was significant with a high likelihood of breaking backwards compatibility I decided to add a new ingress definition template file and the choice as to which to use is based on whether the user uses the old
`.hostname` definition or the new `.hosts` (array of objects)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
