### PR TITLE
Bump appVersion to 3.0.2

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "2.10.4"
+appVersion: "3.0.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.0.0


### PR DESCRIPTION
Fixes #364

### Motivation

The pulsar-helm-chart should track the LTS release 3.0.x . The most recent 3.0.x version is 3.0.2 .

### Modifications

Bumped appVersion to 3.0.2 in Chart.yaml

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
