### PR TITLE
Change default value for rbac.limit_to_namespace and functions.rbac.limit_to_namespace

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -90,7 +90,7 @@ volumes:
 rbac:
   enabled: false
   psp: false
-  limit_to_namespace: false
+  limit_to_namespace: true
 
 
 ## AntiAffinity
@@ -842,7 +842,7 @@ functions:
   # Default is false which deploys functions with ClusterRole and ClusterRoleBinding at the cluster level
   # Set to true to deploy functions with Role and RoleBinding inside the specified namespace
   rbac:
-    limit_to_namespace: false
+    limit_to_namespace: true
   ### Functions Worker service account
   ## templates/broker-service-account.yaml
   service_account:


### PR DESCRIPTION
### Motivation

The default value is false which uses Cluster level Roles and Rolebindings. This is a bad default since there might not be permissions to have cluster level roles and rolebindings and they don't provide any real value compared to namespace level roles and rolebindings.

### Modifications

change the 2 different limit_to_namespace settings from false to true in the values.yaml file.


### Other context

This would be released in 3.2.0 and mentioned as a possible breaking change in the release notes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
