### PR TITLE
docs: Update README for PodDisruptionBudget issue during Pulsar upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,31 @@ Caused by: org.rocksdb.RocksDBException: while open a file for lock: /pulsar/dat
     at org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB.<init>(KeyValueStorageRocksDB.java:196) ~[org.apache.bookkeeper-bookkeeper-server-4.14.4.jar:4.14.4]
     ... 13 more
 ```
+### PodDisruptionBudget Kind Not Found in Kubernetes During Helm Upgrade
+
+If you encounter issues with Helm upgrade, specifically Helm Upgrade Failure [#419](https://github.com/apache/pulsar-helm-chart/issues/419), Here is a sample error you can expect 
+
+```bash
+Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "pulsar-bookie" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
+ensure CRDs are installed first, resource mapping not found for name: "pulsar-broker" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
+ensure CRDs are installed first, resource mapping not found for name: "pulsar-zookeeper" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
+ensure CRDs are installed first]
+```
+you can use the following workaround:
+
+1. Install the Helm plugin for mapping Kubernetes APIs:
+
+    ```bash
+    helm plugin install https://github.com/helm/helm-mapkubeapis
+    ```
+
+2. Run the `helm mapkubeapis` command with the appropriate namespace and release name. In this example, we use the namespace "pulsar" and release name "pulsar":
+
+    ```bash
+    helm mapkubeapis --namespace pulsar pulsar
+    ```
+
+This workaround addresses the issue by mapping Kubernetes APIs and should allow for a successful Helm upgrade.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -237,19 +237,25 @@ Caused by: org.rocksdb.RocksDBException: while open a file for lock: /pulsar/dat
     at org.apache.bookkeeper.bookie.storage.ldb.KeyValueStorageRocksDB.<init>(KeyValueStorageRocksDB.java:196) ~[org.apache.bookkeeper-bookkeeper-server-4.14.4.jar:4.14.4]
     ... 13 more
 ```
-### PodDisruptionBudget Kind Not Found in Kubernetes During Helm Upgrade
 
-If you encounter issues with Helm upgrade, specifically Helm Upgrade Failure [#419](https://github.com/apache/pulsar-helm-chart/issues/419), Here is a sample error you can expect 
+### Recovering from `helm upgrade` error "unable to build kubernetes objects from current release manifest"
 
+Example of the error message:
 ```bash
-Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "pulsar-bookie" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
-ensure CRDs are installed first, resource mapping not found for name: "pulsar-broker" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
-ensure CRDs are installed first, resource mapping not found for name: "pulsar-zookeeper" namespace: "pulsar" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
-ensure CRDs are installed first]
+Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest:
+[resource mapping not found for name: "pulsar-bookie" namespace: "pulsar" from "":
+no matches for kind "PodDisruptionBudget" in version "policy/v1beta1" ensure CRDs are installed first,
+resource mapping not found for name: "pulsar-broker" namespace: "pulsar" from "":
+no matches for kind "PodDisruptionBudget" in version "policy/v1beta1" ensure CRDs are installed first,
+resource mapping not found for name: "pulsar-zookeeper" namespace: "pulsar" from "":
+no matches for kind "PodDisruptionBudget" in version "policy/v1beta1" ensure CRDs are installed first]
 ```
-you can use the following workaround:
 
-1. Install the Helm plugin for mapping Kubernetes APIs:
+Helm documentation [explains issues with managing releases deployed using outdated APIs](https://helm.sh/docs/topics/kubernetes_apis/#helm-users) when the Kubernetes cluster has been upgraded
+to a version where these APIs are removed. This happens regardless of whether the chart in the upgrade includes supported API versions.
+In this case, you can use the following workaround:
+
+1. Install the [Helm mapkubeapis plugin](https://github.com/helm/helm-mapkubeapis):
 
     ```bash
     helm plugin install https://github.com/helm/helm-mapkubeapis
@@ -261,7 +267,7 @@ you can use the following workaround:
     helm mapkubeapis --namespace pulsar pulsar
     ```
 
-This workaround addresses the issue by mapping Kubernetes APIs and should allow for a successful Helm upgrade.
+This workaround addresses the issue by updating in-place Helm release metadata that contains deprecated or removed Kubernetes APIs to a new instance with supported Kubernetes APIs and should allow for a successful Helm upgrade.
 
 ## Uninstall
 


### PR DESCRIPTION
Update README to address "PodDisruptionBudget kind not found" in certain Kubernetes versions.

Addresses #419

### Motivation

This update addresses an issue encountered during the upgrade from Pulsar version 2.x to 3.x. The problem was related to the "PodDisruptionBudget kind not found" error in specific versions of Kubernetes. This modification aims to provide clear instructions on resolving the issue.

### Modifications

I have revised the README file to include information on mitigating the "PodDisruptionBudget kind not found" issue during the upgrade process from Pulsar 2.x to 3.x. in certain Kubernetes versions

### Verifying this change

- [ ] Ensure that the change passes the CI checks.
