### PR TITLE
Add loadBalancerIP support for proxy service

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -32,6 +32,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.proxy.service.type }}
+  {{- with .Values.proxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   ports:
     {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
     - name: http

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -956,6 +956,8 @@ proxy:
   service:
     annotations: {}
     type: LoadBalancer
+    ## Optional. Leave it blank to get next available random IP.
+    loadBalancerIP: ""
   ## Proxy ingress
   ## templates/proxy-ingress.yaml
   ##


### PR DESCRIPTION
### Motivation

There might be cases where the proxy load balancer IP should be static to whitelist it.

### Modifications

I've simply added `loadBalancerIP` field to the proxy service. It's optional, can be empty.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
