### PR TITLE
Fail the chart-testing job if linting fails

### DIFF
--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -86,8 +86,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
-    outputs:
-      no_chart_changes: ${{ steps.ct-lint.outputs.no_chart_changes }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -127,16 +125,7 @@ jobs:
         run: |
           ct lint --check-version-increment=false \
             --validate-maintainers=false \
-            --target-branch ${{ github.event.repository.default_branch }} \
-            | tee /tmp/ct-lint.log || { 
-            if grep -q "No chart changes detected." /tmp/ct-lint.log; then
-              echo no_chart_changes=true >> $GITHUB_OUTPUT
-              exit 0
-            else
-              echo no_chart_changes=false >> $GITHUB_OUTPUT
-              exit 1
-            fi
-          }
+            --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Wait for ssh connection when build fails
         # ssh access is enabled for builds in own forks


### PR DESCRIPTION
### Motivation

The `ct lint` failure doesn't cause the job to fail.

### Modifications

Remove the unnecessary "no_chart_changes" detection which doesn't propagate the failure.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
