### PR TITLE
Support configuring "proxyRoles" in broker

### DIFF
--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -178,6 +178,9 @@ function ci::test_pulsar_producer_consumer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin topics create-subscription -s test pulsar-ci/test/test-topic
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client consume -s test pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin topics create-subscription -s test2 pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url pulsar://pulsar-ci-proxy:6650 produce -m "test-message2" pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url pulsar://pulsar-ci-proxy:6650 consume -s test2 pulsar-ci/test/test-topic
 }
 
 function ci::wait_function_running() {

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -179,8 +179,13 @@ function ci::test_pulsar_producer_consumer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client consume -s test pulsar-ci/test/test-topic
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin topics create-subscription -s test2 pulsar-ci/test/test-topic
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url pulsar://pulsar-ci-proxy:6650 produce -m "test-message2" pulsar-ci/test/test-topic
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url pulsar://pulsar-ci-proxy:6650 consume -s test2 pulsar-ci/test/test-topic
+    if [[ "$PROXY_TLS" == "true" ]]; then
+      PROXY_URL="pulsar+ssl://pulsar-ci-proxy:6651"
+    else
+      PROXY_URL="pulsar://pulsar-ci-proxy:6650"
+    fi
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url "${PROXY_URL}" produce -m "test-message2" pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client --url "${PROXY_URL}" consume -s test2 pulsar-ci/test/test-topic
 }
 
 function ci::wait_function_running() {

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -240,7 +240,14 @@ jobs:
             "jwt-symmetric")
               export SYMMETRIC=true
               ;;
+            "tls")
+              export PROXY_TLS=true
+              ;;
+            "broker-tls")
+              export PROXY_TLS=true
+              ;;
           esac
+          export TEST_SCENARIO=${{ matrix.testScenario.shortname }}
           .ci/chart_test.sh ${{ matrix.testScenario.values_file }}
 
       - name: Collect k8s logs on failure

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -240,14 +240,7 @@ jobs:
             "jwt-symmetric")
               export SYMMETRIC=true
               ;;
-            "tls")
-              export PROXY_TLS=true
-              ;;
-            "broker-tls")
-              export PROXY_TLS=true
-              ;;
           esac
-          export TEST_SCENARIO=${{ matrix.testScenario.shortname }}
           .ci/chart_test.sh ${{ matrix.testScenario.values_file }}
 
       - name: Collect k8s logs on failure

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -113,13 +113,11 @@ data:
   authenticationEnabled: "true"
   {{- if .Values.auth.authorization.enabled }}
   authorizationEnabled: "true"
-  {{- if .Values.auth.useProxyRoles }}
-  superUserRoles: {{ omit .Values.auth.superUsers "proxy" | values | sortAlpha | join "," }}
-  proxyRoles: {{ .Values.auth.superUsers.proxy }}
-  {{- else }}
   superUserRoles: {{ .Values.auth.superUsers | values | sortAlpha | join "," }}
+  {{- if .Values.auth.useProxyRoles }}
+  proxyRoles: {{ .Values.auth.superUsers.proxy }}
   {{- end }}
-
+  
   {{- end }}
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   # token authentication configuration

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -113,7 +113,13 @@ data:
   authenticationEnabled: "true"
   {{- if .Values.auth.authorization.enabled }}
   authorizationEnabled: "true"
+  {{- if .Values.auth.useProxyRoles }}
+  superUserRoles: {{ omit .Values.auth.superUsers "proxy" | values | sortAlpha | join "," }}
+  proxyRoles: {{ .Values.auth.superUsers.proxy }}
+  {{- else }}
   superUserRoles: {{ .Values.auth.superUsers | values | sortAlpha | join "," }}
+  {{- end }}
+
   {{- end }}
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   # token authentication configuration

--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -64,7 +64,11 @@ data:
   # disable authorization on proxy and forward authorization credentials to broker
   authorizationEnabled: "false"
   forwardAuthorizationCredentials: "true"
+  {{- if .Values.auth.useProxyRoles }}
+  superUserRoles: {{ omit .Values.auth.superUsers "proxy" | values | sortAlpha | join "," }}
+  {{- else }}
   superUserRoles: {{ .Values.auth.superUsers | values | sortAlpha | join "," }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   # token authentication configuration

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -249,6 +249,8 @@ auth:
     proxy: "proxy-admin"
     # pulsar-admin client to broker/proxy communication
     client: "admin"
+  # omits the above proxy role from superusers and configures it as a proxy role
+  useProxyRoles: true
 
 ######################################################################
 # External dependencies

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -249,7 +249,8 @@ auth:
     proxy: "proxy-admin"
     # pulsar-admin client to broker/proxy communication
     client: "admin"
-  # omits the above proxy role from superusers and configures it as a proxy role
+  # omits the above proxy role from superusers on the proxy
+  # and configures it as a proxy role on the broker in addition to the superusers
   useProxyRoles: true
 
 ######################################################################


### PR DESCRIPTION
Fixes #427

### Motivation

The chart doesn't currently support configuring "proxyRoles" which makes it unusable when JWT authentication and authorization is used. Configuring proxyRoles is mandatory after https://github.com/apache/pulsar/pull/19455 changes.

### Modifications

Add support for configuring proxyRoles

### Verifying this change

- [ ] Make sure that the change passes the CI checks.