### PR TITLE
Don't use TLS from function instances to brokers by default

### DIFF
--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -118,11 +118,10 @@ data:
   PF_functionRuntimeFactoryConfigs_installUserCodeDependencies: "true"
   PF_functionRuntimeFactoryConfigs_jobNamespace: {{ template "pulsar.namespace" . }}
   PF_functionRuntimeFactoryConfigs_expectedMetricsCollectionInterval: "30"
-  {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
+  {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled .Values.tls.function_instance.enabled) }}
   PF_functionRuntimeFactoryConfigs_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
   PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}/"
-  {{- end }}
-  {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+  {{- else }}
   PF_functionRuntimeFactoryConfigs_pulsarAdminUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}/"
   PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
   {{- end }}
@@ -134,11 +133,10 @@ data:
   PF_kubernetesContainerFactory_installUserCodeDependencies: "true"
   PF_kubernetesContainerFactory_jobNamespace: {{ template "pulsar.namespace" . }}
   PF_kubernetesContainerFactory_expectedMetricsCollectionInterval: "30"
-  {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
+  {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled .Values.tls.function_instance.enabled) }}
   PF_kubernetesContainerFactory_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
   PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}/"
-  {{- end }}
-  {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+  {{- else }}
   PF_kubernetesContainerFactory_pulsarAdminUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}/"
   PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
   {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -229,6 +229,10 @@ tls:
   # settings for generating certs for toolset
   toolset:
     cert_name: tls-toolset
+  # TLS setting for function runtime instance
+  function_instance:
+    # controls the use of TLS for function runtime connections towards brokers
+    enabled: false
 
 # Enable or disable broker authentication and authorization.
 auth:


### PR DESCRIPTION
### Motivation

- CI is currently broken after enabling Pulsar Function testing in all configuration with #434
- When TLS is enabled Function instances cannot communicate to the broker since Function instances don't currently have the custom TLS CA cert available.
- When the function worker runs on the broker, the configuration `PF_tlsAllowInsecureConnection: "true"` has no impact and it's not possible to configure `tlsAllowInsecureConnection=true` only for the function instance. [The function worker uses the broker configuration for the tlsAllowInsecureConnection setting](https://github.com/apache/pulsar/blob/fa81bbcacb33c57c24f0d4ce82d5e25d3ac1f167/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L1820) and changing that would have a larger impact.

### Modifications

- Add new configuration `tls.function_instance.enabled` that defaults to false. This controls whether TLS is used from function instances to the broker.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
