### PR TITLE
Require helm version 3.10 or newer

### DIFF
--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -204,7 +204,7 @@ jobs:
               kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
             testScenario:
               name: "TLS with helm 3.10.0"
-              values_file: .ci/clusters/tls.yaml
+              values_file: .ci/clusters/values-tls.yaml
               shortname: tls
               type: install
             helmVersion: 3.10.0

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -199,9 +199,19 @@ jobs:
               values_file: .ci/clusters/values-psp.yaml
               shortname: psp
               type: upgrade
+          - k8sVersion:
+              version: "1.21.14"
+              kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
+            testScenario:
+              name: "TLS with helm 3.10.0"
+              values_file: .ci/clusters/tls.yaml
+              shortname: tls
+              type: install
+            helmVersion: 3.10.0
     env:
       k8sVersion: ${{ matrix.k8sVersion.kind_image_tag }}
       KUBECTL_VERSION: ${{ matrix.k8sVersion.version }}
+      HELM_VERSION: ${{ matrix.helmVersion || '3.12.3' }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -252,7 +262,7 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Run chart-testing (${{ matrix.testScenario.type || 'install' }})
+      - name: Run chart-testing (${{ matrix.testScenario.type || 'install' }}) with helm ${{ env.HELM_VERSION }}
         run: |
           case "${{ matrix.testScenario.shortname }}" in
             "jwt-symmetric")

--- a/charts/pulsar/templates/check_helm_version.yaml
+++ b/charts/pulsar/templates/check_helm_version.yaml
@@ -18,5 +18,5 @@
 #
 
 {{- if semverCompare "<3.10.0-0" .Capabilities.HelmVersion.Version -}}
-{{- fail "Your Helm version is not supported. Please upgrade to Helm 3.10.0 or later." -}}
+{{- fail "Your Helm version is not supported. Please upgrade to Helm 3.10.0 or later. The recommended version is currently 3.12.3 or newer. You can find more about Helm releases and installation at https://github.com/helm/helm/releases. " -}}
 {{- end -}}

--- a/charts/pulsar/templates/check_helm_version.yaml
+++ b/charts/pulsar/templates/check_helm_version.yaml
@@ -1,0 +1,3 @@
+{{- if semverCompare "<3.10.0-0" .Capabilities.HelmVersion.Version -}}
+{{- fail "Your Helm version is not supported. Please upgrade to Helm 3.10.0 or later." -}}
+{{- end -}}

--- a/charts/pulsar/templates/check_helm_version.yaml
+++ b/charts/pulsar/templates/check_helm_version.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 {{- if semverCompare "<3.10.0-0" .Capabilities.HelmVersion.Version -}}
 {{- fail "Your Helm version is not supported. Please upgrade to Helm 3.10.0 or later." -}}
 {{- end -}}


### PR DESCRIPTION
### Motivation

Installing with helm v3.7.1 fails with this error message:
```
Error: INSTALLATION FAILED: template: pulsar/templates/broker-statefulset.yaml:270:52: executing
 "pulsar/templates/broker-statefulset.yaml" at <eq .Values.broker.storageOffload.driver "aws-s3">: 
error calling eq: incompatible types for comparison
```

### Modifications

- Add check that verifies that Helm version is >= 3.10 (Helm 3.10.0 was released in September 2022) 
- Add CI test that verifies that installing the chart works with Helm 3.10.0

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
