### PR TITLE
Add default configuration for Pulsar Grafana dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,29 @@ verified in some [tests](./.ci/clusters).
 
 ## Grafana Dashboards
 
-The Apache Pulsar Helm Chart uses the `kube-prometheus-stack` Helm Chart to deploy Grafana. Dashboards are loaded via a Kubernetes `ConfigMap`. Please see their documentation for loading those dashboards.
+The Apache Pulsar Helm Chart uses the `kube-prometheus-stack` Helm Chart to deploy Grafana.
 
-The `apache/pulsar` GitHub repo contains some dashboards [here](https://github.com/apache/pulsar/tree/master/grafana).
+There are several ways to configure Grafana dashboards. The default `values.yaml` comes examples of Pulsar dashboards which 
+get downloaded from https://github.com/streamnative/apache-pulsar-grafana-dashboard by URL.
 
-### Third Party Dashboards
+Dashboards can be configured in `values.yaml` or by adding `ConfigMap` items with label `grafana_dashboard: "1"`.
+In `values.yaml`, it's possible to include dashboards by URL or by grafana.com dashboard id (`gnetId` and `revision`).
+Please see the [Grafana Helm chart documentation for importing dashboards](https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#import-dashboards).
 
+You can connect to Grafana by forwarding port 3000
+```
+kubectl port-forward $(kubectl get pods -l app.kubernetes.io/name=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000
+```
+And then opening the browser to http://localhost:3000 . The default user is `admin`.
+
+You can find out the password with this command
+```
+kubectl get secret -l app.kubernetes.io/name=grafana -o=jsonpath="{.items[0].data.admin-password}" | base64 --decode
+```
+
+### Pulsar Grafana Dashboards
+
+* The `apache/pulsar` GitHub repo contains some Grafana dashboards [here](https://github.com/apache/pulsar/tree/master/grafana).
 * StreamNative provides Grafana Dashboards for Apache Pulsar in this [GitHub repository](https://github.com/streamnative/apache-pulsar-grafana-dashboard).
 * DataStax provides Grafana Dashboards for Apache Pulsar in this [GitHub repository](https://github.com/datastax/pulsar-helm-chart/tree/master/helm-chart-sources/pulsar/grafana-dashboards).
 

--- a/README.md
+++ b/README.md
@@ -164,10 +164,9 @@ verified in some [tests](./.ci/clusters).
 
 The Apache Pulsar Helm Chart uses the `kube-prometheus-stack` Helm Chart to deploy Grafana.
 
-There are several ways to configure Grafana dashboards. The default `values.yaml` comes examples of Pulsar dashboards which 
-get downloaded from https://github.com/streamnative/apache-pulsar-grafana-dashboard by URL.
+There are several ways to configure Grafana dashboards. The default `values.yaml` comes with examples of Pulsar dashboards which get downloaded from the Apache-2.0 licensed [streamnative/apache-pulsar-grafana-dashboard OSS project](https://github.com/streamnative/apache-pulsar-grafana-dashboard) by URL.
 
-Dashboards can be configured in `values.yaml` or by adding `ConfigMap` items with label `grafana_dashboard: "1"`.
+Dashboards can be configured in `values.yaml` or by adding `ConfigMap` items with the label `grafana_dashboard: "1"`.
 In `values.yaml`, it's possible to include dashboards by URL or by grafana.com dashboard id (`gnetId` and `revision`).
 Please see the [Grafana Helm chart documentation for importing dashboards](https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#import-dashboards).
 

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1193,6 +1193,77 @@ kube-prometheus-stack:
     enabled: true
   grafana:
     enabled: true
+    # Use random password at installation time for Grafana by default by setting empty value to `adminPassword`.
+    # You can find out the actual password by running the following command:
+    # kubectl get secret -l app.kubernetes.io/name=grafana -o=jsonpath="{.items[0].data.admin-password}" | base64 --decode
+    adminPassword:
+    # Configure Pulsar dashboards for Grafana
+    dashboardProviders:
+      dashboardproviders.yaml:
+        apiVersion: 1
+        providers:
+        - name: 'pulsar'
+          orgId: 1
+          folder: 'Pulsar'
+          type: file
+          disableDeletion: true
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/pulsar
+    dashboards:
+      pulsar:
+        # Download the maintained dashboards from ASL 2.0 licenced repo https://github.com/streamnative/apache-pulsar-grafana-dashboard
+        bookkeeper:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/bookkeeper.json
+          datasource: Prometheus
+        broker:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/broker.json
+          datasource: Prometheus
+        connector_sink:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/connector_sink.json
+          datasource: Prometheus
+        connector_source:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/connector_source.json
+          datasource: Prometheus
+        container:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/container.json
+          datasource: Prometheus
+        functions:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/functions.json
+          datasource: Prometheus
+        jvm:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/jvm.json
+          datasource: Prometheus
+        loadbalance:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/loadbalance.json
+          datasource: Prometheus
+        messaging:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/messaging.json
+          datasource: Prometheus
+        node:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/node.json
+          datasource: Prometheus
+        overview:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/overview.json
+          datasource: Prometheus
+        proxy:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/proxy.json
+          datasource: Prometheus
+        pulsar_detector:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/pulsar_detector.json
+          datasource: Prometheus
+        recovery:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/recovery.json
+          datasource: Prometheus
+        topic:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/topic.json
+          datasource: Prometheus
+        transaction:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/transaction.json
+          datasource: Prometheus
+        zookeeper:
+          url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/zookeeper-3.6.json
+          datasource: Prometheus
   prometheus-node-exporter:
     enabled: true
   alertmanager:


### PR DESCRIPTION
### Motivation

Using Prometheus and Grafana in the Pulsar Helm chart isn't very useful without Pulsar dashboards. 

### Modifications

Add default configuration for Pulsar Grafana dashboards. The Grafana dashboards are referenced by URL from the ASL 2.0 licenced repo https://github.com/streamnative/apache-pulsar-grafana-dashboard which contains maintained Pulsar Grafana dashboards.

The changes in this PR will populate Grafana with the Pulsar dashboards:
<img width="1499" alt="image" src="https://github.com/apache/pulsar-helm-chart/assets/66864/5ed4e386-a071-465c-8d74-6334b393aaef">


### Verifying this change

- [ ] Make sure that the change passes the CI checks.