### PR TITLE
Bugfix/pulsar manager init

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
+++ b/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
@@ -40,13 +40,13 @@ data:
   {{- $secretObj := lookup "v1" "Secret" $namespace $secretName | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
 
-  {{- $ui_user := (get $secretData "UI_USERNAME") | default (.Values.pulsar_manager.admin.ui_username) | default ("pulsar") | b64enc }}
-  {{- $ui_password := (get $secretData "UI_PASSWORD") | default (.Values.pulsar_manager.admin.ui_password) | default (randAlphaNum 32) | b64enc }}
+  {{- $ui_user := ((get $secretData "UI_USERNAME") | b64dec) | default (.Values.pulsar_manager.admin.ui_username) | default ("pulsar") | b64enc }}
+  {{- $ui_password := ((get $secretData "UI_PASSWORD") | b64dec) | default (.Values.pulsar_manager.admin.ui_password) | default (randAlphaNum 32) | b64enc }}
   UI_USERNAME: {{ $ui_user | quote }}
   UI_PASSWORD: {{ $ui_password | quote }}
 
-  {{- $db_user := (get $secretData "DB_USERNAME") | default (.Values.pulsar_manager.admin.db_username) | default ("pulsar") | b64enc }}
-  {{- $db_password := (get $secretData "DB_PASSWORD") | default (.Values.pulsar_manager.admin.db_password) | default (randAlphaNum 32) | b64enc }}
+  {{- $db_user := ((get $secretData "DB_USERNAME") | b64dec) | default (.Values.pulsar_manager.admin.db_username) | default ("pulsar") | b64enc }}
+  {{- $db_password := ((get $secretData "DB_PASSWORD") | b64dec) | default (.Values.pulsar_manager.admin.db_password) | default (randAlphaNum 32) | b64enc }}
   DB_USERNAME: {{ $db_user | quote }}
   DB_PASSWORD: {{ $db_password | quote }}
 

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -82,24 +82,41 @@ spec:
             - |
               ADMIN_URL={{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-admin:{{ .Values.pulsar_manager.adminService.port }}
               CSRF_TOKEN=$(curl http://${ADMIN_URL}/pulsar-manager/csrf-token)
-              {{/* set admin credentials */}}
-              curl -v \
-                -X PUT http://${ADMIN_URL}/pulsar-manager/users/superuser \
-                -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
-                -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN;" \
-                -H 'Content-Type: application/json' \
-                -d '{"name": "'"${USERNAME}"'", "password": "'"${PASSWORD}"'", "description": "Helm-managed Admin Account", "email": "'"${USERNAME}"'@pulsar.org"}'
-
               UI_URL={{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}:{{ .Values.pulsar_manager.service.port }}
-              {{/* login as admin */}}
-              curl -v \
+
+              {{/* check if account is already existing */}}
+              LOGIN_REPLY=$(curl -v \
                 -X POST http://${UI_URL}/pulsar-manager/login \
                 -H 'Accept: application/json, text/plain, */*' \
                 -H 'Content-Type: application/json' \
                 -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
                 -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN" \
                 -sS -D headers.txt \
-                -d '{"username": "'${USERNAME}'", "password": "'${PASSWORD}'"}'
+                -d '{"username": "'${USERNAME}'", "password": "'${PASSWORD}'"}')
+              echo "$LOGIN_REPLY"
+
+              if [ -n "$(echo "$LOGIN_REPLY" | grep 'success')" ]; then
+                echo "account already exists"
+              else
+                echo "creating account"
+                {{/* set admin credentials */}}
+                curl -v \
+                  -X PUT http://${ADMIN_URL}/pulsar-manager/users/superuser \
+                  -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
+                  -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN;" \
+                  -H 'Content-Type: application/json' \
+                  -d '{"name": "'"${USERNAME}"'", "password": "'"${PASSWORD}"'", "description": "Helm-managed Admin Account", "email": "'"${USERNAME}"'@pulsar.org"}'
+                {{/* login as admin */}}
+                LOGIN_REPLY=$(curl -v \
+                  -X POST http://${UI_URL}/pulsar-manager/login \
+                  -H 'Accept: application/json, text/plain, */*' \
+                  -H 'Content-Type: application/json' \
+                  -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
+                  -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN" \
+                  -sS -D headers.txt \
+                  -d '{"username": "'${USERNAME}'", "password": "'${PASSWORD}'"}')
+                echo "$LOGIN_REPLY"
+              fi
 
               LOGIN_TOKEN=$(grep "token:" headers.txt | sed 's/^.*: //')
               LOGIN_JSESSSIONID=$(grep -o "JSESSIONID=[a-zA-Z0-9_]*" headers.txt | sed 's/^.*=//')
@@ -111,15 +128,25 @@ spec:
               BROKER_URL="https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}"
               {{- end }}
               BOOKIE_URL="http://{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}:{{ .Values.bookkeeper.ports.http }}"
+              echo '{ "name": "{{ template "pulsar.fullname" . }}", "broker": "'$BROKER_URL'", "bookie": "'$BOOKIE_URL'"}'
 
-              curl -v \
+              ENVIRONMENT_REPLY=$(curl -v \
                 -X PUT http://${UI_URL}/pulsar-manager/environments/environment \
                 -H 'Content-Type: application/json' \
                 -H "token: $LOGIN_TOKEN" \
                 -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
                 -H "username: $USERNAME" \
                 -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN; JSESSIONID=$LOGIN_JSESSSIONID;" \
-                -d '{ "name": "{{ template "pulsar.fullname" . }}", "broker": "'$BROKER_URL'", "bookie": "'$BOOKIE_URL'"}'
+                -d '{ "name": "{{ template "pulsar.fullname" . }}", "broker": "'$BROKER_URL'", "bookie": "'$BOOKIE_URL'"}')
+              echo "$ENVIRONMENT_REPLY"
+
+              if [ -n "$(echo "$ENVIRONMENT_REPLY" | grep -e 'success' -e 'exist')" ]; then
+                echo "Successfully created / found existing environment"
+                exit 0
+              else
+                echo "Error creating environment"
+                exit 1
+              fi
           env:
             - name: USERNAME
               valueFrom:


### PR DESCRIPTION
Fixes #460 

### Motivation

Stable builds

### Modifications

I made the job rerunnable, such that all things it does are happening exactly once. 
Admin secret is also correctly encoded when using an existent one. 

Interestingly, when adding logs to the test I noticed that the jwt test does not produce logs at the same location like the pulsar manager test, which made the CI checks error. I commented it out for now, but it is a useful tool to debug manager issues.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
