### PR TITLE
Update broker statefulset to check if AWS keys secret name is defined…

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -267,7 +267,7 @@ spec:
           readOnlyRootFilesystem: false
       {{- end }}
         env:
-          {{- if and .Values.broker.storageOffload (eq .Values.broker.storageOffload.driver "aws-s3") }}
+          {{- if and (and .Values.broker.storageOffload (eq .Values.broker.storageOffload.driver "aws-s3")) .Values.broker.storageOffload.secret }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Fixes #465

### Motivation

When using AWS-S3 offload driver, you may be using IAM roles tied to the service account. If that's the case, the AWS access and secret keys aren't needed.

### Modifications

Updated the broker stateful set to also check that the AWS key secret is defined. If it isn't, ignore adding those envFrom statements to the environment.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
