### PR TITLE
add ability to use separate disk for zookeeper tx log

### DIFF
--- a/charts/pulsar/templates/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper-configmap.yaml
@@ -29,6 +29,9 @@ metadata:
     component: {{ .Values.zookeeper.component }}
 data:
   dataDir: /pulsar/data/zookeeper
+  {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
+  PULSAR_PREFIX_dataLogDir: data-log
+  {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
   # enable zookeeper tls
   PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory

--- a/charts/pulsar/templates/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper-configmap.yaml
@@ -30,7 +30,7 @@ metadata:
 data:
   dataDir: /pulsar/data/zookeeper
   {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
-  PULSAR_PREFIX_dataLogDir: data-log
+  PULSAR_PREFIX_dataLogDir: /pulsar/data-log
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
   # enable zookeeper tls

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -209,6 +209,10 @@ spec:
         volumeMounts:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
           mountPath: /pulsar/data
+        {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.datalog.name }}"
+          mountPath: /pulsar/data-log
+        {{- end }}
         {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
         - mountPath: "/pulsar/certs/zookeeper"
           name: zookeeper-certs
@@ -272,5 +276,25 @@ spec:
       selector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+  {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
+  - metadata:
+      name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.datalog.name }}"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.zookeeper.volumes.datalog.size }}
+    {{- if .Values.zookeeper.volumes.datalog.storageClassName }}
+      storageClassName: "{{ .Values.zookeeper.volumes.datalog.storageClassName }}"
+    {{- else if and (not (and .Values.volumes.local_storage .Values.zookeeper.volumes.datalog.local_storage)) .Values.zookeeper.volumes.datalog.storageClass }}
+      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.datalog.name }}"
+    {{- else if and .Values.volumes.local_storage .Values.zookeeper.volumes.datalog.local_storage }}
+      storageClassName: "local-storage"
+    {{- end }}
+    {{- with .Values.zookeeper.volumes.datalog.selector }}
+      selector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -351,10 +351,32 @@ zookeeper:
     fsGroup: 0
     fsGroupChangePolicy: "OnRootMismatch"
   volumes:
+    useSeparateDiskForTxlog: false
     # use a persistent volume or emptyDir
     persistence: true
     data:
       name: data
+      size: 20Gi
+      local_storage: true
+      ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below
+      ##
+      # storageClassName: existent-storage-class
+      #
+      ## Instead if you want to create a new storage class define it below
+      ## If left undefined no storage class will be defined along with PVC
+      ##
+      # storageClass:
+        # type: pd-ssd
+        # fsType: xfs
+        # provisioner: kubernetes.io/gce-pd
+      ## If you want to bind static persistent volumes via selectors, e.g.:
+      # selector:
+        # matchLabels:
+        # app: pulsar-zookeeper
+      selector: {}
+    ## If you set useSeparateDiskForTxlog to true, this section configures the extra volume for the zookeeper transaction log.
+    datalog:
+      name: datalog
       size: 20Gi
       local_storage: true
       ## If you already have an existent storage class and want to reuse it, you can specify its name with the option below


### PR DESCRIPTION
Fixes #475 

### Motivation

Putting the zookeeper transaction log on a separate volume improves performance.

### Modifications

Adds the ability to optionally add a PVC for the zookeeper transaction log and configure zookeeper to use it.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.
