### PR TITLE
pulsar-manager adding support for existing secret

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
+++ b/charts/pulsar/templates/pulsar-manager-admin-secret.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.components.pulsar_manager }}
+{{- if and .Values.components.pulsar_manager ( not .Values.pulsar_manager.admin.existingSecret ) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -151,12 +151,20 @@ spec:
             - name: USERNAME
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.pulsar_manager.admin.existingSecret }}
+                  name: {{ .Values.pulsar_manager.admin.existingSecret | quote }}
+                  {{- else }}
                   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                  {{- end }}
                   key: UI_USERNAME
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.pulsar_manager.admin.existingSecret }}
+                  name: {{ .Values.pulsar_manager.admin.existingSecret | quote }}
+                  {{- else }}
                   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                  {{- end }}
                   key: UI_PASSWORD
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -84,12 +84,20 @@ spec:
           - name: USERNAME
             valueFrom:
               secretKeyRef:
+                {{- if .Values.pulsar_manager.admin.existingSecret }}
+                name: {{ .Values.pulsar_manager.admin.existingSecret | quote }}
+                {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                {{- end }}
                 key: DB_USERNAME
           - name: PASSWORD
             valueFrom:
               secretKeyRef:
+                {{- if .Values.pulsar_manager.admin.existingSecret }}
+                name: {{ .Values.pulsar_manager.admin.existingSecret | quote }}
+                {{- else }}
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
+                {{- end }}
                 key: DB_PASSWORD
           - name: PULSAR_MANAGER_OPTS
             value: "$(PULSAR_MANAGER_OPTS) -Dlog4j2.formatMsgNoLookups=true"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1315,6 +1315,13 @@ pulsar_manager:
   ## And decode any key by using:
   ## kubectl get secret -l component=pulsar-manager -o=jsonpath="{.items[0].data.UI_PASSWORD}" | base64 --decode
   admin:
+    ## Setting a value at existingSecret disables automatic creation of the secret for pulsar_manager admin credentials and instead uses an existing secret to initialize pulsar-manager
+    ## The existing secret should have the following keys:
+    ## DB_PASSWORD: <database password>
+    ## DB_USERNAME: <database username>
+    ## UI_PASSWORD: <UI password>
+    ## UI_USERNAME: <UI username>
+    existingSecret: ""
     ui_username: "pulsar"
     ui_password: ""  # leave empty for random password
     db_username: "pulsar"


### PR DESCRIPTION
Fixes #477 

### Motivation

The existing solution to automatically generate credentials doesn't work in argocd, it detects a constant difference and changes the credentials repeatedly. The alternative of specifying credentials in values files committed to source control is not good practice.
Allowing users to use an existing secret provisioned by the secrets management solution of their choice solves this problem.

### Modifications

Makes the pulsar-manager secret generated by the chart not be created if the value pulsar_manager.admin.existingSecret is specified.
Makes the pulsar-manager initialize job and statefulset utilize an existing secret if it's specified.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.
