### PR TITLE
making .ReleaseIsInstall optional for init jobs

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus .Release.IsInstall) .Values.initialize }}
 {{- if .Values.components.bookkeeper }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-{{- if or .Release.IsInstall .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
 {{- if .Values.components.bookkeeper }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if or .Release.IsInstall .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
 {{- if .Values.components.broker }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus .Release.IsInstall) .Values.initialize }}
 {{- if .Values.components.broker }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus .Release.IsInstall) .Values.initialize }}
 {{- if .Values.components.pulsar_manager }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if or .Release.IsInstall .Values.initialize }}
+{{- if or (and .Values.useReleaseStatus (or .Release.IsInstall .Values.initialize)) .Values.initialize }}
 {{- if .Values.components.pulsar_manager }}
 apiVersion: batch/v1
 kind: Job
@@ -28,7 +28,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}-init
 spec:
-  {{- if or .Values.job.ttl.enabled (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.job.ttl.enabled (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) }}
   ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished | default 600 }}
   {{- end }}
   template:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -36,7 +36,8 @@ clusterDomain: cluster.local
 
 ## Set to true on install
 initialize: false
-
+## Set useReleaseStatus to false if you're deploying this chart using a system that doesn't track .Release.IsInstall or .Release.IsUpgrade (like argocd)
+useReleaseStatus: true
 ## Set cluster name
 # clusterName:
 


### PR DESCRIPTION
Fixes #479 

### Motivation

In solutions like ArgoCD which don't actually track helm state, .ReleaseIsInstall always evaluates to true. We should be able to optionally not use .ReleaseIsInstall to determine whether init jobs should be created/removed

### Modifications

makes a new value `useReleaseStatus` which defaults to true.
When `useReleaseStatus` is set to false, the chart relies only on the value of the `initialize` value to determine whether the init jobs should be created.

This PR also changes an `or`  in the pulsar-manager-cluster-initialize template to an `and`.  With the `or` in place, the value passed at `.Values.job.ttl.enabled` was ignored for all clusters newer than Kubernetes version 1.23.0.  This causes the job to be constantly recreated in argocd.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.
