### PR TITLE
Make job.ttl.enabled consistent and effective only when k8s >= 1.23

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -29,8 +29,8 @@ metadata:
 spec:
 # This feature was previously behind a feature gate for several Kubernetes versions and will default to true in 1.23 and beyond
 # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-{{- if .Values.job.ttl.enabled }}
-  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
+{{- if and .Values.job.ttl.enabled (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished | default 600 }}
 {{- end }}
   template:
     spec:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -30,8 +30,8 @@ metadata:
 spec:
 # This feature was previously behind a feature gate for several Kubernetes versions and will default to true in 1.23 and beyond
 # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-{{- if .Values.job.ttl.enabled }}
-  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished }}
+{{- if and .Values.job.ttl.enabled (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version) }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttl.secondsAfterFinished | default 600 }}
 {{- end }}
   template:
     spec:


### PR DESCRIPTION
### Motivation

- `ttlSecondsAfterFinished` is available in k8s >= 1.23

### Modifications

- make this consistent with https://github.com/apache/pulsar-helm-chart/blob/bc5862d4b0e181ff6af1d73d77233642f9ad2ebc/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml#L31

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
