### PR TITLE
Disable functions by default in values.yaml

### DIFF
--- a/.ci/values-common.yaml
+++ b/.ci/values-common.yaml
@@ -36,6 +36,8 @@ affinity:
 components:
   autorecovery: false
   pulsar_manager: false
+  # enable functions by default in CI
+  functions: true
 
 zookeeper:
   replicaCount: 1

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -120,7 +120,9 @@ components:
   # broker
   broker: true
   # functions
-  functions: true
+  # WARNING! Before enabling functions, make sure that all of your users are trusted since functions run user code
+  # and the current security sandbox is not sufficient to protect against malicious code.
+  functions: false
   # proxy
   proxy: true
   # toolset


### PR DESCRIPTION
### Motivation

Pulsar Functions impose a significant security risk and the default configuration for Pulsar Functions assumes trusted users. 
Pulsar Functions shouldn't be enabled by default.

### Modifications

- Disable Pulsar Functions by default

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
