### PR TITLE
Upgrade appVersion to 3.0.4 to use Pulsar 3.0.4 by default

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "3.0.3"
+appVersion: "3.0.4"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.3.1


### PR DESCRIPTION
Use [Pulsar 3.0.4](https://pulsar.apache.org/release-notes/versioned/pulsar-3.0.4/) by default.