### PR TITLE
Bugfix/pulsar manager persistence

### DIFF
--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -357,8 +357,7 @@ function ci::test_pulsar_manager() {
   until ${KUBECTL} get jobs -n ${NAMESPACE} ${CLUSTER}-pulsar-manager-init -o json | jq -r '.status.conditions[] | select (.type | test("Complete")).status' | grep True; do sleep 3; done
   ${KUBECTL} describe job -n ${NAMESPACE} ${CLUSTER}-pulsar-manager-init
   ${KUBECTL} logs -n ${NAMESPACE} job.batch/${CLUSTER}-pulsar-manager-init
-  # this line errors in some tests? -  i do not know why, but is really useful for debugging, try: cat ./pulsar-manager.log otherwise
-  # ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-pulsar-manager-0 -- cat /pulsar-manager/pulsar-manager/pulsar-manager.log
+  ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-pulsar-manager-0 -- cat /pulsar-manager/pulsar-manager.log
   echo "Checking Podname"
   podname=$(${KUBECTL} get pods -n ${NAMESPACE} -l component=pulsar-manager --no-headers -o custom-columns=":metadata.name")
   echo "Getting pulsar manager UI password"

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -56,6 +56,7 @@ spec:
               done;
         # This init container will wait for at least one broker to be ready before
         # initializing the pulsar-manager
+        {{- if .Values.components.broker }}
         - name: wait-broker-ready
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.proxy "root" .) }}"
           imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
@@ -70,6 +71,7 @@ spec:
                 sleep 10;
                 brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
               done;
+        {{- end }}
       containers:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-init"
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.pulsar_metadata.image "root" .) }}"
@@ -118,6 +120,7 @@ spec:
                 echo "$LOGIN_REPLY"
               fi
 
+              {{- if .Values.components.broker }}
               LOGIN_TOKEN=$(grep "token:" headers.txt | sed 's/^.*: //')
               LOGIN_JSESSSIONID=$(grep -o "JSESSIONID=[a-zA-Z0-9_]*" headers.txt | sed 's/^.*=//')
 
@@ -147,6 +150,15 @@ spec:
                 echo "Error creating environment"
                 exit 1
               fi
+              {{- else }}
+              if [ -n "$(echo "$LOGIN_REPLY" | grep 'success')" ]; then
+                echo "Successfully created / found existing account"
+                exit 0
+              else
+                echo "Error creating account"
+                exit 1
+              fi
+              {{- end }}
           env:
             - name: USERNAME
               valueFrom:

--- a/charts/pulsar/templates/pulsar-manager-configmap.yaml
+++ b/charts/pulsar/templates/pulsar-manager-configmap.yaml
@@ -27,5 +27,18 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
 data:
-{{ toYaml .Values.pulsar_manager.configData | indent 2 }}
+  PULSAR_CLUSTER: {{ template "pulsar.fullname" . }}
+  PULSAR_MANAGER_OPTS: "-Dlog4j2.formatMsgNoLookups=true"
+  {{- if .Values.auth.authentication.enabled }}
+  # auth
+  {{- if eq .Values.auth.authentication.provider "jwt" }}
+  {{- if .Values.auth.authentication.jwt.usingSecretKey }}
+  SECRET_KEY: "file:///pulsar-manager/keys/token/secret.key"
+  {{- else }}
+  PRIVATE_KEY: "file:///pulsar-manager/keys/token/private.key"
+  PUBLIC_KEY: "file:///pulsar-manager/keys/token/public.key"
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{ toYaml .Values.pulsar_manager.configData | indent 2}}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -79,8 +79,6 @@ spec:
           - configMapRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           env:
-          - name: PULSAR_CLUSTER
-            value: {{ template "pulsar.fullname" . }}
           - name: USERNAME
             valueFrom:
               secretKeyRef:
@@ -99,8 +97,6 @@ spec:
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-secret"
                 {{- end }}
                 key: DB_PASSWORD
-          - name: PULSAR_MANAGER_OPTS
-            value: "$(PULSAR_MANAGER_OPTS) -Dlog4j2.formatMsgNoLookups=true"
         {{- if .Values.auth.authentication.enabled }}
         {{- if eq .Values.auth.authentication.provider "jwt" }}
         {{- if .Values.auth.superUsers.manager }}
@@ -110,15 +106,6 @@ spec:
                 key: TOKEN
                 name: "{{ .Release.Name }}-token-{{ .Values.auth.superUsers.manager }}"
         {{- end }}
-        {{- if .Values.auth.authentication.jwt.usingSecretKey }}
-          - name: SECRET_KEY
-            value: file:///pulsar-manager/keys/token/secret.key
-        {{- else }}
-          - name: PRIVATE_KEY
-            value: file:///pulsar-manager/keys/token/private.key
-          - name: PUBLIC_KEY
-            value: file:///pulsar-manager/keys/token/public.key
-        {{- end }}        
         {{- end }}
         {{- end }}          
         {{- include "pulsar.imagePullSecrets" . | nindent 6}}
@@ -146,8 +133,8 @@ spec:
       {{- end }}
       {{- end }}
       {{- if not (and (and .Values.persistence .Values.volumes.persistence) .Values.pulsar_manager.volumes.persistence) }}
-      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
-        emptyDir: {}
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
+          emptyDir: {}
       {{- end }}
 {{- if and (and .Values.persistence .Values.volumes.persistence) .Values.pulsar_manager.volumes.persistence }}
   volumeClaimTemplates:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1279,11 +1279,10 @@ pulsar_manager:
   configData:
     REDIRECT_HOST: "http://127.0.0.1"
     REDIRECT_PORT: "9527"
-    DRIVER_CLASS_NAME: org.postgresql.Driver
-    URL: jdbc:postgresql://127.0.0.1:5432/pulsar_manager
-    LOG_LEVEL: DEBUG
-    SPRING_CONFIGURATION_FILE: "/pulsar-manager/pulsar-manager/application.properties"
-    PULSAR_MANAGER_OPTS: " -Dlog4j2.formatMsgNoLookups=true"
+    LOG_LEVEL: "INFO"
+    # DB
+    URL: "jdbc:postgresql://127.0.0.1:5432/pulsar_manager"
+    DRIVER_CLASS_NAME: "org.postgresql.Driver"
   volumes:
     # use a persistent volume or emptyDir
     persistence: true


### PR DESCRIPTION
Fixes #470 

### Motivation
Reconditioning the pulsar manager after reinstall should not be necessary and data should be persisted.

### Modifications
Multiple modifications. It did not work beforehand because `SPRING_CONFIGURATION_FILE` was set in the environment resulting in a default configuration.


During my investigations, I found out that the **pulsar manager does not setup the database correctly and instead defaults to user/password = pulsar/pulsar**. 
Once the changes on the side of the manager are implemented the same credentials as specified should be used. 
See: https://github.com/apache/pulsar-manager/pull/556

### Verifying this change

- [x] Make sure that the change passes the CI checks.
