### PR TITLE
enable message peeking in pulsar manager

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1283,6 +1283,8 @@ pulsar_manager:
     # DB
     URL: "jdbc:postgresql://127.0.0.1:5432/pulsar_manager"
     DRIVER_CLASS_NAME: "org.postgresql.Driver"
+    # enables the "message peeking" feature
+    PULSAR_PEEK_MESSAGE: "true"
   volumes:
     # use a persistent volume or emptyDir
     persistence: true


### PR DESCRIPTION
### Motivation
Right now you cannot see the backlog of a subscription inside the manager, this flag is needed to toggle the behavior to enable message peeking.

### Modifications
add flag: PULSAR_PEEK_MESSAGE: "true"

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
