### PR TITLE
Increase default Prometheus scrape interval to 60s

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -288,8 +288,8 @@ zookeeper:
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
-    interval: 10s
-    scrapeTimeout: 10s
+    interval: 60s
+    scrapeTimeout: 60s
     metricRelabelings:
       # - action: labeldrop
       #   regex: cluster
@@ -460,8 +460,8 @@ bookkeeper:
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
-    interval: 10s
-    scrapeTimeout: 10s
+    interval: 60s
+    scrapeTimeout: 60s
     metricRelabelings:
       # - action: labeldrop
       #   regex: cluster
@@ -666,8 +666,8 @@ autorecovery:
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
-    interval: 10s
-    scrapeTimeout: 10s
+    interval: 60s
+    scrapeTimeout: 60s
     metricRelabelings:
       # - action: labeldrop
       #   regex: cluster
@@ -762,8 +762,8 @@ broker:
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
-    interval: 10s
-    scrapeTimeout: 10s
+    interval: 60s
+    scrapeTimeout: 60s
     metricRelabelings:
       # - action: labeldrop
       #   regex: cluster
@@ -994,8 +994,8 @@ proxy:
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
-    interval: 10s
-    scrapeTimeout: 10s
+    interval: 60s
+    scrapeTimeout: 60s
     metricRelabelings:
       # - action: labeldrop
       #   regex: cluster


### PR DESCRIPTION
### Motivation

The default scrape interval of 10 seconds doesn't make much sense for metrics. That causes unnecessary load on the system when metrics are so granular. Some stats in Pulsar broker get updated every 60 seconds by default.

### Modifications

* Increase scrape interval to 60 seconds
* Increase scape timeout to 60 seconds

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
