### PR TITLE
Fix prometheus node-exporter crashloop

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1256,6 +1256,8 @@ kube-prometheus-stack:
           datasource: Prometheus
   prometheus-node-exporter:
     enabled: true
+    hostRootFsMount: 
+      enabled: false
   alertmanager:
     enabled: false
 

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1256,7 +1256,7 @@ kube-prometheus-stack:
           datasource: Prometheus
   prometheus-node-exporter:
     enabled: true
-    hostRootFsMount: 
+    hostRootFsMount:
       enabled: false
   alertmanager:
     enabled: false


### PR DESCRIPTION
### Motivation

prometheus-node-exporter pods are in a crash loop at least when running in Docker Desktop.
This is issue https://github.com/prometheus-community/helm-charts/issues/467 . 

### Modifications

Disable the feature by default which is causing the problem.
```yaml
kube-prometheus-stack:
  prometheus-node-exporter:
    hostRootFsMount: 
      enabled: false
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
