### PR TITLE
Change default statusFilePath to /pulsar/logs/status

### DIFF
--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -41,7 +41,7 @@ data:
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
   zooKeeperSessionTimeoutMillis: "30000"
-  statusFilePath: "{{ template "pulsar.home" . }}/status"
+  statusFilePath: "{{ template "pulsar.home" . }}/logs/status"
 
   # Tiered storage settings
   {{- if .Values.broker.storageOffload.driver }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -225,7 +225,7 @@ spec:
         {{- end }}
           bin/apply-config-from-env.py conf/broker.conf;
           bin/gen-yml-from-env.py conf/functions_worker.yml;
-          echo "OK" > status;
+          echo "OK" > "${statusFilePath:-status}";
           {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 10 }}
           bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} get {{ template "pulsar.broker.znode" . }};
           while [ $? -eq 0 ]; do

--- a/charts/pulsar/templates/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy-configmap.yaml
@@ -28,7 +28,7 @@ metadata:
     component: {{ .Values.proxy.component }}
 data:
   clusterName: {{ template "pulsar.cluster.name" . }}
-  statusFilePath: "{{ template "pulsar.home" . }}/status"
+  statusFilePath: "{{ template "pulsar.home" . }}/logs/status"
   # prometheus needs to access /metrics endpoint
   webServicePort: "{{ .Values.proxy.ports.containerPorts.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -185,7 +185,7 @@ spec:
           {{ .Values.proxy.additionalCommand }}
         {{- end }}
           bin/apply-config-from-env.py conf/proxy.conf &&
-          echo "OK" > status &&
+          echo "OK" > "${statusFilePath:-status}" &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
         # prometheus needs to access /metrics endpoint


### PR DESCRIPTION
### Motivation

`/pulsar` directory is no longer writable by default

### Modifications

change the default `statusFilePath` to `/pulsar/logs/status`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
