### PR TITLE
Allow broker's service clusterIP customisation

### DIFF
--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -29,6 +29,7 @@ metadata:
   annotations:
 {{ toYaml .Values.broker.service.annotations | indent 4 }}
 spec:
+  type: ClusterIP
   ports:
   # prometheus needs to access /metrics endpoint
   - name: http
@@ -43,7 +44,17 @@ spec:
   - name: "{{ .Values.tlsPrefix }}pulsarssl"
     port: {{ .Values.broker.ports.pulsarssl }}
   {{- end }}
-  clusterIP: None
+  {{- if and .Values.broker.service .Values.broker.service.clusterIP }}
+  {{- if eq .Values.broker.service.clusterIP "auto" }}
+  clusterIP: ""
+  {{- else if regexMatch "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$" .Values.broker.service.clusterIP }}
+  clusterIP: "{{ .Values.broker.service.clusterIP }}"
+  {{- else }}
+  clusterIP: "None"
+  {{- end }}
+  {{- else }}
+  clusterIP: "None"
+  {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -44,17 +44,7 @@ spec:
   - name: "{{ .Values.tlsPrefix }}pulsarssl"
     port: {{ .Values.broker.ports.pulsarssl }}
   {{- end }}
-  {{- if and .Values.broker.service .Values.broker.service.clusterIP }}
-  {{- if eq .Values.broker.service.clusterIP "auto" }}
-  clusterIP: ""
-  {{- else if regexMatch "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$" .Values.broker.service.clusterIP }}
   clusterIP: "{{ .Values.broker.service.clusterIP }}"
-  {{- else }}
-  clusterIP: "None"
-  {{- end }}
-  {{- else }}
-  clusterIP: "None"
-  {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -769,6 +769,13 @@ broker:
       #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
+  ## optional, you can specify a clusterIP for the broker's service
+  # 1. any valid IPv4 can be used to rewrite the clusterIP
+  # 2. use clusterIP: 'auto' to let kubernetes pick a clusterIP (i.e. clusterIP: "")
+  # 3. otherwise, clusterIP is set to "None" (i.e. headless mode)
+  # More on clusterIP kubernetes service type: https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip
+  # service:
+  #   clusterIP: 255.255.255.255
   ports:
     http: 8080
     https: 8443

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -769,13 +769,6 @@ broker:
       #   regex: cluster
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
-  ## optional, you can specify a clusterIP for the broker's service
-  # 1. any valid IPv4 can be used to rewrite the clusterIP
-  # 2. use clusterIP: 'auto' to let kubernetes pick a clusterIP (i.e. clusterIP: "")
-  # 3. otherwise, clusterIP is set to "None" (i.e. headless mode)
-  # More on clusterIP kubernetes service type: https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip
-  # service:
-  #   clusterIP: 255.255.255.255
   ports:
     http: 8080
     https: 8443
@@ -868,6 +861,11 @@ broker:
   ## templates/broker-service.yaml
   ##
   service:
+    # clusterIP can be one of the three, which determines the type of k8s service deployed for broker
+    # 1. a valid IPv4 address -> non-headless service, let you select the IPv4 address
+    # 2. '' -> non-headless service, k8s picks an IPv4 address
+    # 3. 'None' -> headless
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip
     clusterIP: "None"
     annotations: {}
   ## Broker PodDisruptionBudget

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -868,6 +868,7 @@ broker:
   ## templates/broker-service.yaml
   ##
   service:
+    clusterIP: "None"
     annotations: {}
   ## Broker PodDisruptionBudget
   ## templates/broker-pdb.yaml


### PR DESCRIPTION
Fixes #497

### Motivation

This customisation is useful to configure headless vs non-headless broker's service. The default is headless broker service, i.e. a service for which kubernetes  does not allocate an IP address (https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip). A headless service is a very simple type of service that doesn't seem to work well when pulsar service is exposed by pulsar-proxy via a nodeport.

### Modifications

Adding 3 modes to deploy the pulsar broker service:
1. a valid IPv4 address
2. auto mode, i.e. clusterIP: ''
3. headless, i.e. clusterIP: 'None'

### Verifying this change

- [X] Run custom verification 
- [ ] Make sure that the change passes the CI checks.

### Custom verification
#### Mode 1. -- valid IPv4 address
##### Valid
values.yaml
```
broker:
  service:
    clusterIP: 255.255.255.255
```
Running `helm diff  upgrade pulsar-test ./apache/pulsar-helm-chart/charts/pulsar/ -n pulsar -f ./values.yaml`, returns
```
+   type: ClusterIP
    ports:
    # prometheus needs to access /metrics endpoint
    - name: http
      port: 8080
    - name: "pulsar"
      port: 6650
+   clusterIP: "255.255.255.255"
    selector:
      app: pulsar
      release: pulsar-test
      component: broker
```
##### Invalid
values.yaml
```
broker:
  service:
    clusterIP: 255.255.255.256
```
Running `helm diff  upgrade pulsar-test ./apache/pulsar-helm-chart/charts/pulsar/ -n pulsar -f ./values.yaml`, returns
```
+   type: ClusterIP
    ports:
    # prometheus needs to access /metrics endpoint
    - name: http
      port: 8080
    - name: "pulsar"
      port: 6650
+   clusterIP: "None"
    selector:
      app: pulsar
      release: pulsar-test
      component: broker
```
#### Mode 2. -- `auto` 
values.yaml
```
broker:
  service:
    clusterIP: 'auto'
```
Running `helm diff  upgrade pulsar-test ./apache/pulsar-helm-chart/charts/pulsar/ -n pulsar -f ./values.yaml`, returns
```
+   type: ClusterIP
    ports:
    # prometheus needs to access /metrics endpoint
    - name: http
      port: 8080
    - name: "pulsar"
      port: 6650
+   clusterIP: ""
    selector:
      app: pulsar
      release: pulsar-test
      component: broker
```
#### Mode 3. -- headless
values.yaml
```
broker:
```
Running `helm diff  upgrade pulsar-test ./apache/pulsar-helm-chart/charts/pulsar/ -n pulsar -f ./values.yaml`, returns
```
+   type: ClusterIP
    ports:
    # prometheus needs to access /metrics endpoint
    - name: http
      port: 8080
    - name: "pulsar"
      port: 6650
+   clusterIP: "None"
    selector:
      app: pulsar
      release: pulsar-test
      component: broker
```