### PR TITLE
Use Pulsar 3.0.5 as the default Pulsar version (appVersion)

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "3.0.4"
+appVersion: "3.0.5"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.4.0


### PR DESCRIPTION
### Motivation

- Pulsar 3.0.5 has been released with many fixes

### Modifications

- update chart's `appVersion` to `3.0.5`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
