### PR TITLE
Upgrade kube-prometheus-stack to 59.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,20 @@ helm upgrade -f pulsar.yaml \
 
 For more detailed information, see our [Upgrading](http://pulsar.apache.org/docs/helm-upgrade/) guide.
 
+## Upgrading from Helm Chart version 3.0.0-3.4.x to 3.5.0 version and above
+
+The kube-prometheus-stack version has been upgraded to 59.x.x in Pulsar Helm Chart version 3.5.0 .
+Before running "helm upgrade", you should first upgrade the Prometheus Operator CRDs as [instructed
+in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-58x-to-59x). 
+
+There's a script to run the required commands:
+```shell
+./scripts/kube-prometheus-stack/upgrade_prometheus_operator_crds.sh 0.74.0
+```
+
+After, this you can proceed with `helm upgrade`.
+
+
 ## Upgrading from Helm Chart version 3.0.0-3.2.x to 3.3.0 version and above
 
 The kube-prometheus-stack version has been upgraded to 56.x.x in Pulsar Helm Chart version 3.3.0 .
@@ -253,7 +267,7 @@ in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/
 
 There's a script to run the required commands:
 ```shell
-./scripts/kube-prometheus-stack/upgrade_prometheus_operator_crds.sh
+./scripts/kube-prometheus-stack/upgrade_prometheus_operator_crds.sh 0.71.0
 ```
 
 After, this you can proceed with `helm upgrade`.

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v2
 appVersion: "3.0.5"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
-version: 3.4.1
+version: 3.5.0
 kubeVersion: ">=1.21.0-0"
 home: https://pulsar.apache.org
 sources:
@@ -33,6 +33,6 @@ maintainers:
     email: dev@pulsar.apache.org
 dependencies:
   - name: kube-prometheus-stack
-    version: 56.x.x
+    version: 59.x.x
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled

--- a/scripts/kube-prometheus-stack/upgrade_prometheus_operator_crds.sh
+++ b/scripts/kube-prometheus-stack/upgrade_prometheus_operator_crds.sh
@@ -19,16 +19,11 @@
 #
 
 # This script is used to upgrade the Prometheus Operator CRDs before running "helm upgrade"
-# source: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-55x-to-56x
+# source: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#upgrading-an-existing-release-to-a-new-major-version
 # "Run these commands to update the CRDs before applying the upgrade."
-# "--force-conflicts" is required to upgrade the CRDs. Following instructions from https://github.com/prometheus-community/helm-charts/issues/2489
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.71.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+PROMETHEUS_OPERATOR_VERSION="${1:-"0.74.0"}"
+PREFIX_URL="https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd"
+for crd in alertmanagerconfigs alertmanagers podmonitors probes prometheusagents prometheuses prometheusrules scrapeconfigs servicemonitors thanosrulers; do
+  # "--force-conflicts" is required to upgrade the CRDs. Following instructions from https://github.com/prometheus-community/helm-charts/issues/2489
+  kubectl apply --server-side --force-conflicts -f "${PREFIX_URL}/monitoring.coreos.com_${crd}.yaml"
+done


### PR DESCRIPTION
### Motivation

- Keep kube-prometheus-stack updated so that it doesn't fall behind
  - Older versions contain CVEs which don't get fixed anymore

### Modifications

- upgrade from 56.x.x to 59.x.x
- add upgrading instructions

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
