### PR TITLE
Add defaultPulsarImageRepository configuration

### DIFF
--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -126,5 +126,5 @@ imagePullSecrets:
 Create full image name
 */}}
 {{- define "pulsar.imageFullName" -}}
-{{- printf "%s:%s" .image.repository (.image.tag | default .root.Values.defaultPulsarImageTag | default .root.Chart.AppVersion) -}}
+{{- printf "%s:%s" (.image.repository | default .root.Values.defaultPulsarImageRepository) (.image.tag | default .root.Values.defaultPulsarImageTag | default .root.Chart.AppVersion) -}}
 {{- end -}}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -130,6 +130,9 @@ components:
   # pulsar manager
   pulsar_manager: false
 
+# default image repository for pulsar images
+defaultPulsarImageRepository: apachepulsar/pulsar-all
+
 # default image tag for pulsar images
 # uses chart's appVersion when unspecified
 defaultPulsarImageTag:
@@ -142,32 +145,38 @@ images:
   # imagePullSecrets:
   #   - secretName
   zookeeper:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent
   bookie:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent
   autorecovery:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent
   broker:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent
   proxy:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent
   functions:
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
   pulsar_manager:
@@ -713,7 +722,8 @@ pulsar_metadata:
   component: pulsar-init
   image:
     # the image used for running `pulsar-cluster-initialize` job
-    repository: apachepulsar/pulsar-all
+    # uses defaultPulsarImageRepository when unspecified
+    repository:
     # uses defaultPulsarImageTag when unspecified
     tag:
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Fixes #464

### Motivation

Currently using a custom image requires updating multiple keys in the values.yaml file.
It's easy to miss updating all locations where `apachepulsar/pulsar-all` is referenced.

### Modifications

- add defaultPulsarImageRepository configuration

### Verifying this change

- [ ] Make sure that the change passes the CI checks.