### PR TITLE
Make zookeeper healthchecks compatible with Alpine's busybox nc

### DIFF
--- a/.ci/clusters/values-pulsar-latest.yaml
+++ b/.ci/clusters/values-pulsar-latest.yaml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+defaultPulsarImageTag: 3.3.0

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -213,6 +213,13 @@ jobs:
               version: "1.21.14"
               kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
             testScenario:
+              name: "Pulsar Latest"
+              values_file: .ci/clusters/values-pulsar-latest.yaml
+              shortname: pulsar-latest
+          - k8sVersion:
+              version: "1.21.14"
+              kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
+            testScenario:
               name: "Upgrade TLS"
               values_file: .ci/clusters/values-tls.yaml
               shortname: tls

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -209,13 +209,13 @@ jobs:
             values_file: .ci/clusters/values-pulsar-manager.yaml
             shortname: pulsar-manager
         include:
-          - k8sVersion:
-              version: "1.21.14"
-              kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
-            testScenario:
-              name: "Pulsar Latest"
-              values_file: .ci/clusters/values-pulsar-latest.yaml
-              shortname: pulsar-latest
+          # - k8sVersion:
+          #     version: "1.21.14"
+          #     kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093
+          #   testScenario:
+          #     name: "Pulsar Latest"
+          #     values_file: .ci/clusters/values-pulsar-latest.yaml
+          #     shortname: pulsar-latest
           - k8sVersion:
               version: "1.21.14"
               kind_image_tag: v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
         {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
         {{- $zkConnectCommand = print "openssl s_client -quiet -crlf -connect localhost:" .Values.zookeeper.ports.clientTls " -cert /pulsar/certs/zookeeper/tls.crt -key /pulsar/certs/zookeeper/tls.key" -}}
         {{- else -}}
-        {{- $zkConnectCommand = print "nc -q 1 localhost " .Values.zookeeper.ports.client -}}
+        {{- $zkConnectCommand = print "nc localhost " .Values.zookeeper.ports.client -}}
         {{- end }}
         {{- if .Values.zookeeper.probe.readiness.enabled }}
         {{- if and (semverCompare "<1.25-0" .Capabilities.KubeVersion.Version) .Values.rbac.enabled .Values.rbac.psp }}
@@ -172,7 +172,7 @@ spec:
             - "{{ .Values.zookeeper.probe.readiness.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
+            - '{ echo ruok; sleep 1; } | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.readiness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.readiness.timeoutSeconds }}
@@ -186,7 +186,7 @@ spec:
             - "{{ .Values.zookeeper.probe.liveness.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
+            - '{ echo ruok; sleep 1; } | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.liveness.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.liveness.timeoutSeconds }}
@@ -200,7 +200,7 @@ spec:
             - "{{ .Values.zookeeper.probe.startup.timeoutSeconds }}"
             - bash
             - -c
-            - 'echo ruok | {{ $zkConnectCommand }} | grep imok'
+            - '{ echo ruok; sleep 1; } | {{ $zkConnectCommand }} | grep imok'
           initialDelaySeconds: {{ .Values.zookeeper.probe.startup.initialDelaySeconds }}
           periodSeconds: {{ .Values.zookeeper.probe.startup.periodSeconds }}
           timeoutSeconds: {{ .Values.zookeeper.probe.startup.timeoutSeconds }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -156,9 +156,9 @@ spec:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         {{- $zkConnectCommand := "" -}}
         {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-        {{- $zkConnectCommand = print "openssl s_client -quiet -crlf -connect localhost:" .Values.zookeeper.ports.clientTls " -cert /pulsar/certs/zookeeper/tls.crt -key /pulsar/certs/zookeeper/tls.key" -}}
+        {{- $zkConnectCommand = print "openssl s_client -quiet -crlf -connect 127.0.0.1:" .Values.zookeeper.ports.clientTls " -cert /pulsar/certs/zookeeper/tls.crt -key /pulsar/certs/zookeeper/tls.key" -}}
         {{- else -}}
-        {{- $zkConnectCommand = print "nc localhost " .Values.zookeeper.ports.client -}}
+        {{- $zkConnectCommand = print "nc 127.0.0.1 " .Values.zookeeper.ports.client -}}
         {{- end }}
         {{- if .Values.zookeeper.probe.readiness.enabled }}
         {{- if and (semverCompare "<1.25-0" .Capabilities.KubeVersion.Version) .Values.rbac.enabled .Values.rbac.psp }}


### PR DESCRIPTION
### Motivation

The apachepulsar/pulsar:3.3.0 image contains busybox nc which doesn't support `-q 1` command line option.
See apache/pulsar#22872.

### Modifications

- replace `-q 1` with the use of `sleep 1` in the input. 
  - Solution from https://unix.stackexchange.com/a/274603.
- replace "localhost" with "127.0.0.1" (so that IPv4 gets selected?)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.