### PR TITLE
Add initContainers to templates

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -123,6 +123,9 @@ spec:
         volumeMounts:
         {{- include "pulsar.autorecovery.certs.volumeMounts" . | nindent 8 }}
       {{- end }}
+      {{- if .Values.autorecovery.initContainers }}
+        {{- toYaml .Values.autorecovery.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.autorecovery "root" .) }}"

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -128,7 +128,10 @@ spec:
       {{- end}}
         volumeMounts:
         {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
-      {{- end}}
+      {{- end }}
+      {{- if .Values.bookkeeper.initContainers }}
+        {{- toYaml .Values.bookkeeper.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.bookie "root" .) }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -183,6 +183,9 @@ spec:
         volumeMounts:
         {{- include "pulsar.broker.certs.volumeMounts" . | nindent 10 }}
       {{- end }}
+      {{- if .Values.broker.initContainers }}
+        {{- toYaml .Values.broker.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.broker "root" .) }}"

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -144,6 +144,9 @@ spec:
               brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
             done;
       {{- end}}
+      {{- if .Values.proxy.initContainers }}
+        {{- toYaml .Values.proxy.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.proxy "root" .) }}"

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -55,6 +55,10 @@ spec:
 {{ toYaml .Values.pulsar_manager.tolerations | indent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.pulsar_manager.gracePeriod }}
+      {{- if .Values.pulsar_manager.initContainers }}
+      initContainers:
+        {{- toYaml .Values.pulsar_manager.initContainers | nindent 6 }}
+      {{- end }}
       containers:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           image: "{{ .Values.images.pulsar_manager.repository }}:{{ .Values.images.pulsar_manager.tag }}"

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -59,6 +59,10 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+      {{- if .Values.toolset.initContainers }}
+      initContainers:
+        {{- toYaml .Values.toolset.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
         {{- if (and .Values.images.toolset .Values.images.toolset.repository) }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -105,6 +105,10 @@ spec:
       securityContext:
 {{ toYaml .Values.zookeeper.securityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.zookeeper.initContainers }}
+      initContainers:
+        {{- toYaml .Values.zookeeper.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.zookeeper "root" .) }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -312,6 +312,7 @@ zookeeper:
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
+  initContainers: []
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -488,6 +489,7 @@ bookkeeper:
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
+  initContainers: []
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -696,6 +698,7 @@ autorecovery:
   # so the metrics are correctly rendered in grafana dashboard
   component: recovery
   replicaCount: 1
+  initContainers: []
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -802,6 +805,7 @@ broker:
     maxReplicas: 3
     metrics: ~
     behavior: ~
+  initContainers: []
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -1044,6 +1048,7 @@ proxy:
     maxReplicas: 3
     metrics: ~
     behavior: ~
+  initContainers: []
   # This is how prometheus discovers this component
   podMonitor:
     enabled: true
@@ -1192,12 +1197,13 @@ proxy:
     maxUnavailable: 1
 
 ## Pulsar ToolSet
-## templates/toolset-deployment.yaml
+## templates/toolset-statefulset.yaml
 ##
 toolset:
   component: toolset
   useProxy: true
   replicaCount: 1
+  initContainers: []
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   # nodeSelector:
@@ -1331,6 +1337,7 @@ kube-prometheus-stack:
 pulsar_manager:
   component: pulsar-manager
   replicaCount: 1
+  initContainers: []
   # True includes annotation for statefulset that contains hash of corresponding configmap, which will cause pods to restart on configmap change
   restartPodsOnConfigMapChange: false
   # nodeSelector:

--- a/examples/values-init-containers.yaml
+++ b/examples/values-init-containers.yaml
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## start
+components:
+  # zookeeper
+  zookeeper: true
+  # bookkeeper
+  bookkeeper: true
+  # bookkeeper - autorecovery
+  autorecovery: true
+  # broker
+  broker: true
+  # functions
+  functions: true
+  # proxy
+  proxy: true
+  # toolset
+  toolset: true
+  # pulsar manager
+  pulsar_manager: true
+  
+zookeeper:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The zookeeper initContainers work as expected"']
+
+bookkeeper:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The bookkeeper initContainers work as expected"']
+      
+autorecovery:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The autorecovery initContainers work as expected"']
+      
+broker:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The broker initContainers work as expected"']
+  
+proxy:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The proxy initContainers work as expected"']
+      
+toolset:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The toolset initContainers work as expected"']
+
+pulsar_manager:
+  initContainers:
+    - name: pre-startup-checks
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The pulsar_manager initContainers work as expected"']


### PR DESCRIPTION
### Motivation

Fixes #491,#240

### Modifications

- Add `initContainers` to the templates of each component.
- Add `examples/values-init-containers.yaml`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
