### PR TITLE
Upgrade cert-manager to v1.12.13

### DIFF
--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -25,7 +25,7 @@ set -e
 NAMESPACE=cert-manager
 NAME=cert-manager
 # check compatibility with k8s versions from https://cert-manager.io/docs/installation/supported-releases/
-VERSION=v1.11.4
+VERSION=v1.12.13
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."


### PR DESCRIPTION
- cert-manager 1.12 is a LTS release, EOL until May 2025