### PR TITLE
Support using self generated certificates

### DIFF
--- a/charts/pulsar/templates/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls-certs-internal.yaml
@@ -21,6 +21,7 @@
 {{- if .Values.certs.internal_issuer.enabled }}
 
 {{- if .Values.tls.proxy.enabled }}
+{{- if .Values.tls.proxy.createCert }}
 apiVersion: "{{ .Values.certs.internal_issuer.apiVersion }}"
 kind: Certificate
 metadata:
@@ -62,6 +63,7 @@ spec:
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
 ---
+{{- end }}
 {{- end }}
 
 {{- if or .Values.tls.broker.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled) }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -226,6 +226,7 @@ tls:
   proxy:
     enabled: false
     cert_name: tls-proxy
+    createCert: true # set to false if you want to use an existing certificate
   # settings for generating certs for broker
   broker:
     enabled: false
@@ -1425,6 +1426,9 @@ pulsar_manager:
     ui_password: ""  # leave empty for random password
     db_username: "pulsar"
     db_password: ""  # leave empty for random password
+    dbExistingSecret: ""
+    dbUsernameKey: "" # leave empty to use default key
+    dbPasswordKey: "" # leave empty to use default key
 
 # These are jobs where job ttl configuration is used
 # pulsar-helm-chart/charts/pulsar/templates/pulsar-cluster-initialize.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -226,7 +226,7 @@ tls:
   proxy:
     enabled: false
     cert_name: tls-proxy
-    createCert: true # set to false if you want to use an existing certificate
+    createCert: true  # set to false if you want to use an existing certificate
   # settings for generating certs for broker
   broker:
     enabled: false
@@ -1426,9 +1426,6 @@ pulsar_manager:
     ui_password: ""  # leave empty for random password
     db_username: "pulsar"
     db_password: ""  # leave empty for random password
-    dbExistingSecret: ""
-    dbUsernameKey: "" # leave empty to use default key
-    dbPasswordKey: "" # leave empty to use default key
 
 # These are jobs where job ttl configuration is used
 # pulsar-helm-chart/charts/pulsar/templates/pulsar-cluster-initialize.yaml


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

We get a SSL cert from another provider (not managed by cert-manager) and do not have a way to provide this to our proxies.

### Modifications

Added a variable that defaults to true and will remove the cert-manager certificate.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
