### PR TITLE
feat: Support to customize broker podManagementPolicy from values.yaml

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
   podManagementPolicy: {{ $stsObj.spec.podManagementPolicy }}
   {{- else }}
   {{- if not .Values.components.functions }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.broker.podManagementPolicy }}
   {{- else }}
   podManagementPolicy: OrderedReady
   {{- end }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -48,8 +48,10 @@ spec:
   {{- if $stsObj }}
   podManagementPolicy: {{ $stsObj.spec.podManagementPolicy }}
   {{- else }}
-  {{- if not .Values.components.functions }}
+  {{- if .Values.broker.podManagementPolicy }}
   podManagementPolicy: {{ .Values.broker.podManagementPolicy }}
+  {{- else if not .Values.components.functions }}
+  podManagementPolicy: Parallel
   {{- else }}
   podManagementPolicy: OrderedReady
   {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -806,7 +806,8 @@ broker:
     maxReplicas: 3
     metrics: ~
     behavior: ~
-  podManagementPolicy: Parallel
+  # The podManagementPolicy cannot be changed on an existing broker. If you want to make this change, you will need to manually recreate the StatefulSet.
+  podManagementPolicy:
   initContainers: []
   # This is how prometheus discovers this component
   podMonitor:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -806,7 +806,7 @@ broker:
     maxReplicas: 3
     metrics: ~
     behavior: ~
-  # The podManagementPolicy cannot be changed on an existing broker. If you want to make this change, you will need to manually recreate the StatefulSet.
+  # The podManagementPolicy cannot be modified for an existing deployment. If you need to change this value, you will need to manually delete the existing broker StatefulSet and then redeploy the chart.
   podManagementPolicy:
   initContainers: []
   # This is how prometheus discovers this component

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -806,6 +806,7 @@ broker:
     maxReplicas: 3
     metrics: ~
     behavior: ~
+  podManagementPolicy: Parallel
   initContainers: []
   # This is how prometheus discovers this component
   podMonitor:


### PR DESCRIPTION
Modification to make the podManagementPolicy on the broker adjustable, independent of the component function value, in cases where we do not want to use the built-in functions, but rather an extension like the FunctionMesh Operator.

### Motivation
podManagementPolicy should be customizable on the broker regardless of the value of the component function.

### Modifications
podManagementPolicy can be customized from the values file.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
