### PR TITLE
Add topologyspreadconstraint to deploy pods in sts cross different az evenly

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -62,6 +62,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     {{- end }}
+    {{- if .Values.autorecovery.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.autorecovery.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.autorecovery.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -59,6 +59,10 @@ spec:
       tolerations:
 {{ toYaml .Values.bookkeeper.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.bookkeeper.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.bookkeeper.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -78,6 +78,10 @@ spec:
       tolerations:
 {{ toYaml .Values.broker.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.broker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.broker.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -61,6 +61,10 @@ spec:
       tolerations:
 {{ toYaml .Values.proxy.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.proxy.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -54,6 +54,10 @@ spec:
       tolerations:
 {{ toYaml .Values.pulsar_manager.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.pulsar_manager.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.pulsar_manager.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.pulsar_manager.gracePeriod }}
       {{- if .Values.pulsar_manager.initContainers }}
       initContainers:

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -57,6 +57,10 @@ spec:
       tolerations:
 {{ toYaml .Values.toolset.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.toolset.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.toolset.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
       {{- if .Values.toolset.initContainers }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
       tolerations:
 {{ toYaml .Values.zookeeper.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.zookeeper.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.zookeeper.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -358,6 +358,8 @@ zookeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -533,6 +535,8 @@ bookkeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -721,6 +725,8 @@ autorecovery:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   # tolerations: []
   gracePeriod: 30
@@ -850,6 +856,8 @@ broker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: preferredDuringSchedulingIgnoredDuringExecution
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1088,6 +1096,8 @@ proxy:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1209,6 +1219,8 @@ toolset:
   restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1343,6 +1355,8 @@ pulsar_manager:
   restartPodsOnConfigMapChange: false
   # nodeSelector:
   # cloud.google.com/gke-nodepool: default-pool
+  # set topologySpreadConstraint to deploy pods across different zones
+  topologySpreadConstraints: []
   annotations: {}
   tolerations: []
   gracePeriod: 30


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-helm-chart/issues/521

### Motivation
I see broker sts doesn't support topology constraint configuration. That means 2 pods in the sts may possible depoyed to on az in kubernetes cluster.
Reference doc: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/

### Modifications
Added a topology spread constraint configuration to deployed the pods in sts spread to different az, so that under an AZ outage, the impact can be only limited to small number of brokers.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
