### PR TITLE
Test with 4.0.0-candidate-1

### DIFF
--- a/.ci/clusters/values-pulsar-latest.yaml
+++ b/.ci/clusters/values-pulsar-latest.yaml
@@ -17,4 +17,5 @@
 # under the License.
 #
 
-defaultPulsarImageTag: 3.3.1
+#defaultPulsarImageRepository: apachepulsar/pulsar-all
+#defaultPulsarImageTag: 3.3.1

--- a/.ci/values-common.yaml
+++ b/.ci/values-common.yaml
@@ -86,3 +86,6 @@ proxy:
 
 toolset:
   useProxy: false
+
+defaultPulsarImageRepository: lhotari/pulsar-all
+defaultPulsarImageTag: 4.0.0-92448d5


### PR DESCRIPTION
### Motivation

Testing that the Apache Pulsar Helm chart CI passes with the 4.0.0-candidate-1 image:
https://lists.apache.org/thread/jqnvrh45tly9yzyvgcq33v7tsqv12ng3

This PR shouldn't be merged.