### PR TITLE
Fix compatibility with Pulsar 3.3.x+ docker images where /pulsar isn't writable

### DIFF
--- a/charts/pulsar/templates/keytool.yaml
+++ b/charts/pulsar/templates/keytool.yaml
@@ -36,9 +36,14 @@ data:
     crtFile=/pulsar/certs/${component}/tls.crt
     keyFile=/pulsar/certs/${component}/tls.key
     caFile=/pulsar/certs/ca/ca.crt
-    p12File=/pulsar/${component}.p12
-    keyStoreFile=/pulsar/${component}.keystore.jks
-    trustStoreFile=/pulsar/${component}.truststore.jks
+    tlsDir=/tmp/pulsar-tls$$
+    p12File=${tlsDir}/${component}.p12
+    keyStoreFile=${tlsDir}/${component}.keystore.jks
+    trustStoreFile=${tlsDir}/${component}.truststore.jks
+
+    # create tmp dir for keystore and truststore files
+    mkdir ${tlsDir}
+    chmod 0700 ${tlsDir}
     
     function checkFile() {
         local file=$1


### PR DESCRIPTION
### Motivation

Fixes this issue:
```
[pod/pulsar-ci-zookeeper-0/pulsar-ci-zookeeper] pkcs12: Can't open "/pulsar/zookeeper.p12" for writing, Permission denied
[pod/pulsar-ci-zookeeper-0/pulsar-ci-zookeeper] Importing keystore /pulsar/zookeeper.p12 to /pulsar/zookeeper.keystore.jks...
```

### Modifications

Use a temporary directory to store the keystore files.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Additional context

- requires https://github.com/apache/pulsar/pull/23362 changes on Pulsar side to add openssl to the image.