### PR TITLE
Use Pulsar 3.0.7 image by default to address CVE-2024-47561

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "3.0.6"
+appVersion: "3.0.7"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.5.0


### PR DESCRIPTION
### Motivation

Use most recent Pulsar 3.0.7 image which contains the fix for critical 9.3/10 level RCE vulnerability in Avro Java SDK
<1.11.4, CVE-2024-47561

### Modifications

Bump appVersion to 3.0.7

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
