### PR TITLE
fix: broker extraEnv variable

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -316,8 +316,8 @@ spec:
                 name: {{ .Values.broker.storageOffload.secret }}
                 key: AZURE_STORAGE_ACCESS_KEY
           {{- end }}
-        {{- if .Values.broker.extreEnvs }}
-{{- toYaml .Values.broker.extreEnvs | nindent 10 }}
+        {{- if .Values.broker.extraEnvs }}
+{{- toYaml .Values.broker.extraEnvs | nindent 10 }}
         {{- end }}
       volumes:
       {{- if .Values.broker.extraVolumes }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -262,10 +262,6 @@ spec:
         - name: "{{ .Values.tlsPrefix }}pulsarssl"
           containerPort: {{ .Values.broker.ports.pulsarssl }}
         {{- end }}
-{{- if .Values.broker.extreEnvs }}
-        env:
-{{ toYaml .Values.broker.extreEnvs | indent 8 }}
-{{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
@@ -320,6 +316,9 @@ spec:
                 name: {{ .Values.broker.storageOffload.secret }}
                 key: AZURE_STORAGE_ACCESS_KEY
           {{- end }}
+        {{- if .Values.broker.extreEnvs }}
+{{- toYaml .Values.broker.extreEnvs | nindent 10 }}
+        {{- end }}
       volumes:
       {{- if .Values.broker.extraVolumes }}
 {{ toYaml .Values.broker.extraVolumes | indent 6 }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -216,9 +216,9 @@ spec:
         securityContext:
           readOnlyRootFilesystem: false
       {{- end }}
-{{- if .Values.proxy.extreEnvs }}
+{{- if .Values.proxy.extraEnvs }}
         env:
-{{ toYaml .Values.proxy.extreEnvs | indent 8 }}
+{{ toYaml .Values.proxy.extraEnvs | indent 8 }}
 {{- end }}
         envFrom:
         - configMapRef:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -884,12 +884,12 @@ broker:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
-  extreEnvs:
-   - name: POD_NAME
-     valueFrom:
-       fieldRef:
-         apiVersion: v1
-         fieldPath: metadata.name
+  extreEnvs: []
+  #  - name: POD_NAME
+  #    valueFrom:
+  #      fieldRef:
+  #        apiVersion: v1
+  #        fieldPath: metadata.name
   ## Broker configmap
   ## templates/broker-configmap.yaml
   ## Keys in broker.conf can be overridden here. Use PULSAR_PREFIX_ to add keys to broker.conf.

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -884,12 +884,12 @@ broker:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
-  extreEnvs: []
-#    - name: POD_NAME
-#      valueFrom:
-#        fieldRef:
-#          apiVersion: v1
-#          fieldPath: metadata.name
+  extreEnvs:
+   - name: POD_NAME
+     valueFrom:
+       fieldRef:
+         apiVersion: v1
+         fieldPath: metadata.name
   ## Broker configmap
   ## templates/broker-configmap.yaml
   ## Keys in broker.conf can be overridden here. Use PULSAR_PREFIX_ to add keys to broker.conf.

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -884,7 +884,7 @@ broker:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
-  extreEnvs: []
+  extraEnvs: []
   #  - name: POD_NAME
   #    valueFrom:
   #      fieldRef:
@@ -1124,7 +1124,7 @@ proxy:
   #     readOnly: true
   extraVolumes: []
   extraVolumeMounts: []
-  extreEnvs: []
+  extraEnvs: []
 #    - name: POD_IP
 #      valueFrom:
 #        fieldRef:


### PR DESCRIPTION
Fixes #539

### Motivation

fix `env` object declared twice ni broker.yaml

QUESTION: It's possible to rename extreEnvs to extraEnvs  ?

### Modifications

*Use only one env object in broker*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
