### PR TITLE
fix: update role: deployments and statefulsets belong to apiGroups "apps"

### DIFF
--- a/charts/pulsar/templates/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker-cluster-role-binding.yaml
@@ -63,12 +63,22 @@ rules:
   resources:
   - configmaps
   verbs: ["get", "list", "watch"]
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: [""]
   resources:
     - pods
     - services
-    - deployments
     - secrets
+  verbs:
+    - list
+    - watch
+    - get
+    - update
+    - create
+    - delete
+    - patch
+- apiGroups: ["apps"]
+  resources:
+    - deployments
     - statefulsets
   verbs:
     - list


### PR DESCRIPTION
Fixes # rbac role

### Motivation

deployments and statefulsets belong to apiGroups "app"

If a user only have a namespace auth ,  Its will break down when helm install this chart . Because of  wrong apiGroups.

``` 
"my-milvus-0-pulsar-broker-role" is forbidden: user "[xxxxxxxxx](mailto:milvus-storage@376054.sa)" (groups=["xxxxxxxx" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["deployments"], Verbs:["watch" "update" "create" "delete" "patch"]}
{APIGroups:[""], Resources:["statefulsets"], Verbs:["watch" "update" "create" "delete" "patch"]}
{APIGroups:["apps"], Resources:["pods"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["apps"], Resources:["secrets"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["apps"], Resources:["services"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["extensions"], Resources:["pods"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["extensions"], Resources:["secrets"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["extensions"], Resources:["services"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
{APIGroups:["extensions"], Resources:["statefulsets"], Verbs:["list" "watch" "get" "update" "create" "delete" "patch"]}
``` 

### Modifications

Change role apiGroups.
Delete extensions apiGroups

### Verifying this change

- [x] Make sure that the change passes the CI checks.
