### PR TITLE
feat: add loadBalancerClass for proxy and pulsar-manager

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -35,6 +35,9 @@ spec:
   {{- with .Values.proxy.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- with .Values.proxy.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
   {{- if .Values.proxy.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.proxy.service.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -33,7 +33,7 @@ spec:
   {{- if .Values.pulsar_manager.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.pulsar_manager.service.externalTrafficPolicy }}
   {{- end }}
-  {{- with .pulsar_manager.proxy.service.loadBalancerClass }}
+  {{- with .pulsar_manager.service.loadBalancerClass }}
   loadBalancerClass: {{ . }}
   {{- end }}
   {{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -33,6 +33,9 @@ spec:
   {{- if .Values.pulsar_manager.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.pulsar_manager.service.externalTrafficPolicy }}
   {{- end }}
+  {{- with .pulsar_manager.proxy.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
   {{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.pulsar_manager.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -33,7 +33,7 @@ spec:
   {{- if .Values.pulsar_manager.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.pulsar_manager.service.externalTrafficPolicy }}
   {{- end }}
-  {{- with .pulsar_manager.service.loadBalancerClass }}
+  {{- with .Values.pulsar_manager.service.loadBalancerClass }}
   loadBalancerClass: {{ . }}
   {{- end }}
   {{- if .Values.pulsar_manager.service.loadBalancerSourceRanges }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1180,7 +1180,7 @@ proxy:
     ## Restrict traffic through the load balancer to specified IPs on providers supporting it.
     # loadBalancerSourceRanges:
     #   - 10.0.0.0/8
-    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is beeded by metallb)
+    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is needed by metallb)
     # loadBalancerClass: ""
     # Optional. When setting proxy.service.type is set to NodePort, nodePorts allows to choose the port that will be open on each node to proxy requests to each destination proxy service.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
@@ -1408,7 +1408,7 @@ pulsar_manager:
     ## Restrict traffic through the load balancer to specified IPs on providers supporting it.
     # loadBalancerSourceRanges:
     #   - 10.0.0.0/8
-    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is beeded by metallb)
+    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is needed by metallb)
     # loadBalancerClass: ""
   adminService:
     type: ClusterIP

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1180,6 +1180,8 @@ proxy:
     ## Restrict traffic through the load balancer to specified IPs on providers supporting it.
     # loadBalancerSourceRanges:
     #   - 10.0.0.0/8
+    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is beeded by metallb)
+    # loadBalancerClass: ""
     # Optional. When setting proxy.service.type is set to NodePort, nodePorts allows to choose the port that will be open on each node to proxy requests to each destination proxy service.
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     nodePorts:
@@ -1406,6 +1408,8 @@ pulsar_manager:
     ## Restrict traffic through the load balancer to specified IPs on providers supporting it.
     # loadBalancerSourceRanges:
     #   - 10.0.0.0/8
+    # Set a loadBalancerClass for loadbalancer service. (example: loadBalancerClass is beeded by metallb)
+    # loadBalancerClass: ""
   adminService:
     type: ClusterIP
     port: 7750


### PR DESCRIPTION
Fixes #545

### Motivation

Add loadBalancerClass for use metallb loadbalancer service on private kubernetes cluster

### Modifications

Add loadbalancerClass on proxy-service.yaml and pulsar-manager-service.yaml

### Verifying this change

- [x] Make sure that the change passes the CI checks.
