### PR TITLE
Correct pulsar proxy prometheus.io/port annotation

### DIFF
--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         component: {{ .Values.proxy.component }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.proxy.ports.http }}"
+        prometheus.io/port: "{{ .Values.proxy.ports.containerPorts.http }}"
         {{- if .Values.proxy.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
         {{- end }}


### PR DESCRIPTION
Fixes #547 

### Motivation
Being able to scrape metrics is good.  The existing version of the chart can be worked around by setting both the service and containerPort http ports to the same value, but the default values file has them different, and it's a confusing gotcha.

### Modifications
Corrected the annotation to use the value used to set the containerPort instead of the value used to set the service port.


### Verifying this change

- [x] Make sure that the change passes the CI checks.
