### PR TITLE
Add support for admin port on ZooKeeper

### DIFF
--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -40,6 +40,8 @@ spec:
       port: {{ .Values.zookeeper.ports.leaderElection }}
     - name: "{{ .Values.tcpPrefix }}client"
       port: {{ .Values.zookeeper.ports.client }}
+    - name: admin
+      port: {{ .Values.zookeeper.ports.admin }}
     {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
     - name: "{{ .Values.tlsPrefix }}client-tls"
       port: {{ .Values.zookeeper.ports.clientTls }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -141,6 +141,8 @@ spec:
           containerPort: {{ .Values.zookeeper.ports.follower }}
         - name: leader-election
           containerPort: {{ .Values.zookeeper.ports.leaderElection }}
+        - name: admin
+          containerPort: {{ .Values.zookeeper.ports.admin }}
         {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
         - name: client-tls
           containerPort: {{ .Values.zookeeper.ports.clientTls }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -330,6 +330,7 @@ zookeeper:
     clientTls: 2281
     follower: 2888
     leaderElection: 3888
+    admin: 9990
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   probe:


### PR DESCRIPTION
Fixes #549

### Motivation

We need to be able to access the ZooKeeper admin endpoint to perform automated snapshots to an external system. 

### Modifications

I have added the admin port to the list of Zookeeper ports, and made the relevant changes on the zookeeper-service.yaml & zookeeper-statefulset.yaml to use the admin port.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
