### PR TITLE
Fix invalid internal server name in Oxia config

### DIFF
--- a/charts/pulsar/templates/_oxia.tpl
+++ b/charts/pulsar/templates/_oxia.tpl
@@ -89,7 +89,7 @@ namespaces:
     replicationFactor: {{ .Values.oxia.replicationFactor }}
 servers:
   - public:  {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-svc.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.oxia.server.ports.public }}
-    internal:  {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-svc.{{ template "pulsar.namespace" . }}.svc:{{ .Values.oxia.server.ports.internal }}
+    internal:  {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-svc.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.oxia.server.ports.internal }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The name with `.svc` suffix doesn't resolve. it's better to use the fully qualified name.
The [original Oxia helm chart doesn't contain the `.svc` suffix either](https://github.com/streamnative/oxia/blob/79fea6ac5a5ba61572505149a7024a46bb936ded/deploy/charts/oxia-cluster/templates/coordinator-configmap.yaml#L31). 