### PR TITLE
Fix Oxia config so that it includes a list of all pods in the statefulset

### DIFF
--- a/.ci/clusters/values-oxia.yaml
+++ b/.ci/clusters/values-oxia.yaml
@@ -25,10 +25,10 @@ components:
   functions: false
 
 oxia:
-  initialShardCount: 1
-  replicationFactor: 1
+  initialShardCount: 3
+  replicationFactor: 3
   server:
-    replicas: 1
-    memoryLimit: 256Mi
-    dbCacheSizeMb: 128
+    replicas: 3
+    memoryLimit: 200Mi
+    dbCacheSizeMb: 100
     storageSize: 1Gi

--- a/.ci/clusters/values-oxia.yaml
+++ b/.ci/clusters/values-oxia.yaml
@@ -29,6 +29,7 @@ oxia:
   replicationFactor: 3
   server:
     replicas: 3
+    cpuLimit: 333m
     memoryLimit: 200Mi
     dbCacheSizeMb: 100
     storageSize: 1Gi

--- a/charts/pulsar/templates/_oxia.tpl
+++ b/charts/pulsar/templates/_oxia.tpl
@@ -88,8 +88,14 @@ namespaces:
     initialShardCount: {{ .Values.oxia.initialShardCount }}
     replicationFactor: {{ .Values.oxia.replicationFactor }}
 servers:
-  - public:  {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-svc.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.oxia.server.ports.public }}
-    internal:  {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-svc.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.oxia.server.ports.internal }}
+  {{- $servicenameFQDN := printf "%s-%s-svc.%s.svc.cluster.local" (include "pulsar.fullname" .) .Values.oxia.component (include "pulsar.namespace" .) }}
+  {{- $podnamePrefix := printf "%s-%s-server-" (include "pulsar.fullname" .) .Values.oxia.component }}
+  {{- range until (int .Values.oxia.server.replicas) }}
+  {{- $podnameIndex := . }}
+  {{- $podnameFQDN := printf "%s%d.%s" $podnamePrefix $podnameIndex $servicenameFQDN }}
+  - public: {{ $podnameFQDN }}:{{ $.Values.oxia.server.ports.public }}
+    internal: {{ $podnameFQDN }}:{{ $.Values.oxia.server.ports.internal }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/pulsar/templates/_oxia.tpl
+++ b/charts/pulsar/templates/_oxia.tpl
@@ -88,13 +88,15 @@ namespaces:
     initialShardCount: {{ .Values.oxia.initialShardCount }}
     replicationFactor: {{ .Values.oxia.replicationFactor }}
 servers:
-  {{- $servicenameFQDN := printf "%s-%s-svc.%s.svc.cluster.local" (include "pulsar.fullname" .) .Values.oxia.component (include "pulsar.namespace" .) }}
+  {{- $servicename := printf "%s-%s-svc" (include "pulsar.fullname" .) .Values.oxia.component }}
+  {{- $fqdnSuffix := printf "%s.svc.cluster.local" (include "pulsar.namespace" .) }}
   {{- $podnamePrefix := printf "%s-%s-server-" (include "pulsar.fullname" .) .Values.oxia.component }}
   {{- range until (int .Values.oxia.server.replicas) }}
   {{- $podnameIndex := . }}
-  {{- $podnameFQDN := printf "%s%d.%s" $podnamePrefix $podnameIndex $servicenameFQDN }}
+  {{- $podname := printf "%s%d.%s" $podnamePrefix $podnameIndex $servicename }}
+  {{- $podnameFQDN := printf "%s.%s" $podname $fqdnSuffix }}
   - public: {{ $podnameFQDN }}:{{ $.Values.oxia.server.ports.public }}
-    internal: {{ $podnameFQDN }}:{{ $.Values.oxia.server.ports.internal }}
+    internal: {{ $podname }}:{{ $.Values.oxia.server.ports.internal }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fixes #551

### Motivation

There's an issue in the current Oxia configuration in Apache Pulsar Helm chart described in #551

### Modifications

The config.yaml was invalid. In the original Oxia Helm chart, all pods of the statefulset are listed:
https://github.com/streamnative/oxia/blob/79fea6ac5a5ba61572505149a7024a46bb936ded/deploy/charts/oxia-cluster/templates/coordinator-configmap.yaml#L29-L32
A subtle mistake was made when this template was added to the Apache Pulsar Helm chart.
This PR adds similar logic to the configuration. The template logic contains variable names that make it easy to follow the logic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
