### PR TITLE
Fix helm chart to allow configurable ingress pathType

### DIFF
--- a/charts/pulsar/templates/proxy-ingress.yaml
+++ b/charts/pulsar/templates/proxy-ingress.yaml
@@ -59,7 +59,7 @@ spec:
               servicePort: {{ .Values.proxy.ports.http }}
               {{- end }}
             {{- else }}
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.proxy.ingress.pathType }}
             backend:
               service:
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/pulsar-manager-ingress.yaml
+++ b/charts/pulsar/templates/pulsar-manager-ingress.yaml
@@ -55,7 +55,7 @@ spec:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.service.targetPort }}
             {{- else }}
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.pulsar_manager.ingress.pathType }}
             backend:
               service:
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1297,6 +1297,7 @@ proxy:
 
     hostname: ""
     path: "/"
+    pathType: ImplementationSpecific
   ## Proxy PodDisruptionBudget
   ## templates/proxy-pdb.yaml
   ##
@@ -1523,6 +1524,7 @@ pulsar_manager:
 
     hostname: ""
     path: "/"
+    pathType: ImplementationSpecific
 
   ## On first install, the helm chart tries to reuse an existing secret with matching name by default
   ## if this should fail it uses the given username and password to create a new secret


### PR DESCRIPTION


### Motivation

The ingress configuration for pulsar_manager and for proxy components are failing on some circumstances due to `pathType` is hardcoded.

### Modifications

The proposed modifications is that `pathType` value may be modified from values.yaml file. The change has set the `pathType` default value to the same that was harcoded `pathType: ImplementationSpecific` so the change is backward compatible.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
