### PR TITLE
Support external cert secret

### DIFF
--- a/charts/pulsar/templates/_autorecovery.tpl
+++ b/charts/pulsar/templates/_autorecovery.tpl
@@ -48,7 +48,7 @@ Define autorecovery tls certs mounts
 - name: autorecovery-certs
   mountPath: "/pulsar/certs/autorecovery"
   readOnly: true
-{{- if .Values.tls.autorecovery.untrustedCa }}
+{{- if .Values.tls.autorecovery.selfSigned }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
@@ -74,7 +74,7 @@ Define autorecovery tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
-{{- if .Values.tls.autorecovery.untrustedCa }}
+{{- if .Values.tls.autorecovery.selfSigned }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
@@ -107,8 +107,8 @@ done;
 Define Autorecovery TLS certificate secret name
 */}}
 {{- define "pulsar.autorecovery.tls.secret.name" -}}
-{{- if .Values.tls.autorecovery.certSecretName -}}
-{{- .Values.tls.autorecovery.certSecretName -}}
+{{- if .Values.tls.autorecovery.existingCertSecret -}}
+{{- .Values.tls.autorecovery.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}
 {{- end -}}

--- a/charts/pulsar/templates/_autorecovery.tpl
+++ b/charts/pulsar/templates/_autorecovery.tpl
@@ -66,7 +66,7 @@ Define autorecovery tls certs volumes
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
 - name: autorecovery-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
+    secretName: "{{ template "pulsar.autorecovery.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -74,7 +74,7 @@ Define autorecovery tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -98,3 +98,14 @@ until timeout 15 bin/bookkeeper shell whatisinstanceid; do
   sleep 3;
 done;
 {{- end }}
+
+{{/*
+Define Autorecovery TLS certificate secret name
+*/}}
+{{- define "pulsar.autorecovery.tls.secret.name" -}}
+{{- if .Values.tls.autorecovery.certSecretName -}}
+{{- .Values.tls.autorecovery.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_autorecovery.tpl
+++ b/charts/pulsar/templates/_autorecovery.tpl
@@ -48,9 +48,11 @@ Define autorecovery tls certs mounts
 - name: autorecovery-certs
   mountPath: "/pulsar/certs/autorecovery"
   readOnly: true
+{{- if .Values.tls.autorecovery.untrustedCa }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   mountPath: "/pulsar/keytool/keytool.sh"
@@ -72,12 +74,14 @@ Define autorecovery tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
+{{- if .Values.tls.autorecovery.untrustedCa }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   configMap:

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -67,7 +67,7 @@ Define bookie tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled) }}
 - name: bookie-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
+    secretName: "{{ template "pulsar.bookie.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -75,7 +75,7 @@ Define bookie tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -144,3 +144,14 @@ until timeout 15 bin/bookkeeper shell whatisinstanceid; do
 done;
 {{- end }}
 {{- end }}
+
+{{/*
+Define Bookie TLS certificate secret name
+*/}}
+{{- define "pulsar.bookie.tls.secret.name" -}}
+{{- if .Values.tls.bookie.certSecretName -}}
+{{- .Values.tls.bookie.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -73,7 +73,7 @@ Define bookie tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
-{{- if .Values.tls.bookkeeper.untrustedCa }}
+{{- if .Values.tls.bookkeeper.selfSigned }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
@@ -151,8 +151,8 @@ done;
 Define Bookie TLS certificate secret name
 */}}
 {{- define "pulsar.bookie.tls.secret.name" -}}
-{{- if .Values.tls.bookie.certSecretName -}}
-{{- .Values.tls.bookie.certSecretName -}}
+{{- if .Values.tls.bookie.existingCertSecret -}}
+{{- .Values.tls.bookie.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}
 {{- end -}}

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -73,12 +73,14 @@ Define bookie tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
+{{- if .Values.tls.bookkeeper.untrustedCa }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   configMap:

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -81,7 +81,7 @@ Define broker tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: ""{{ template "pulsar.tls.ca.secret.name" . }}""
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -73,7 +73,7 @@ Define broker tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled)) }}
 - name: broker-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
+    secretName: "{{ template "pulsar.broker.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -81,7 +81,7 @@ Define broker tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
+    secretName: ""{{ template "pulsar.tls.ca.secret.name" . }}""
     items:
     - key: ca.crt
       path: ca.crt
@@ -93,3 +93,14 @@ Define broker tls certs volumes
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define Broker TLS certificate secret name
+*/}}
+{{- define "pulsar.broker.tls.secret.name" -}}
+{{- if .Values.tls.broker.certSecretName -}}
+{{- .Values.tls.broker.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -55,9 +55,11 @@ Define broker tls certs mounts
 - name: broker-certs
   mountPath: "/pulsar/certs/broker"
   readOnly: true
+{{- if .Values.tls.broker.untrustedCa }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   mountPath: "/pulsar/keytool/keytool.sh"
@@ -79,12 +81,14 @@ Define broker tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
+{{- if .Values.tls.broker.untrustedCa }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   configMap:

--- a/charts/pulsar/templates/_broker.tpl
+++ b/charts/pulsar/templates/_broker.tpl
@@ -55,7 +55,7 @@ Define broker tls certs mounts
 - name: broker-certs
   mountPath: "/pulsar/certs/broker"
   readOnly: true
-{{- if .Values.tls.broker.untrustedCa }}
+{{- if .Values.tls.broker.selfSigned }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
@@ -81,7 +81,7 @@ Define broker tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
-{{- if .Values.tls.broker.untrustedCa }}
+{{- if .Values.tls.broker.selfSigned }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
@@ -102,8 +102,8 @@ Define broker tls certs volumes
 Define Broker TLS certificate secret name
 */}}
 {{- define "pulsar.broker.tls.secret.name" -}}
-{{- if .Values.tls.broker.certSecretName -}}
-{{- .Values.tls.broker.certSecretName -}}
+{{- if .Values.tls.broker.existingCertSecret -}}
+{{- .Values.tls.broker.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}
 {{- end -}}

--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -143,6 +143,6 @@ Define TLS CA secret name
 {{- if .Values.tls.common.caSecretName -}}
 {{- .Values.tls.common.caSecretName -}}
 {{- else -}}
-{{ .Release.Name }}-ca-tls
+{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}
 {{- end -}}
 {{- end -}}

--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -140,8 +140,8 @@ Lookup pull policy, default to defaultPullPolicy
 Define TLS CA secret name
 */}}
 {{- define "pulsar.tls.ca.secret.name" -}}
-{{- if .Values.tls.common.caSecretName -}}
-{{- .Values.tls.common.caSecretName -}}
+{{- if .Values.tls.common.existingCaSecret -}}
+{{- .Values.tls.common.existingCaSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.ca_suffix }}
 {{- end -}}

--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -136,3 +136,13 @@ Lookup pull policy, default to defaultPullPolicy
 {{- printf "%s" (.image.pullPolicy | default .root.Values.defaultPullPolicy) -}}
 {{- end -}}
 
+{{/*
+Define TLS CA secret name
+*/}}
+{{- define "pulsar.tls.ca.secret.name" -}}
+{{- if .Values.tls.common.caSecretName -}}
+{{- .Values.tls.common.caSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-ca-tls
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_proxy.tpl
+++ b/charts/pulsar/templates/_proxy.tpl
@@ -1,0 +1,84 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+
+{{/*
+Define Proxy TLS certificate secret name
+*/}}
+{{- define "pulsar.proxy.tls.secret.name" -}}
+{{- if .Values.tls.proxy.certSecretName -}}
+{{- .Values.tls.proxy.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define proxy certs mounts
+*/}}
+{{- define "pulsar.proxy.certs.volumeMounts" -}}
+{{- if and .Values.tls.enabled (or .Values.tls.proxy.enabled .Values.tls.broker.enabled) }}
+{{- if .Values.tls.proxy.enabled }}
+- mountPath: "/pulsar/certs/proxy"
+  name: proxy-certs
+  readOnly: true
+{{- if .Values.tls.proxy.untrustedCa }}
+- mountPath: "/pulsar/certs/ca"
+  name: proxy-ca
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- if .Values.tls.broker.enabled }}
+- mountPath: "/pulsar/certs/broker"
+  name: broker-ca
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define proxy certs volumes
+*/}}
+{{- define "pulsar.proxy.certs.volumes" -}}
+{{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
+{{- if .Values.tls.proxy.untrustedCa }}
+- name: proxy-ca
+  secret:
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
+    items:
+      - key: ca.crt
+        path: ca.crt
+  {{- end }}
+- name: proxy-certs
+  secret:
+    secretName: "{{ template "pulsar.proxy.tls.secret.name" . }}"
+    items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+{{- end }}
+{{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+- name: broker-ca
+  secret:
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
+    items:
+      - key: ca.crt
+        path: ca.crt
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/_proxy.tpl
+++ b/charts/pulsar/templates/_proxy.tpl
@@ -21,8 +21,8 @@ under the License.
 Define Proxy TLS certificate secret name
 */}}
 {{- define "pulsar.proxy.tls.secret.name" -}}
-{{- if .Values.tls.proxy.certSecretName -}}
-{{- .Values.tls.proxy.certSecretName -}}
+{{- if .Values.tls.proxy.existingCertSecret -}}
+{{- .Values.tls.proxy.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}
 {{- end -}}
@@ -37,7 +37,7 @@ Define proxy certs mounts
 - mountPath: "/pulsar/certs/proxy"
   name: proxy-certs
   readOnly: true
-{{- if .Values.tls.proxy.untrustedCa }}
+{{- if .Values.tls.proxy.selfSigned }}
 - mountPath: "/pulsar/certs/ca"
   name: proxy-ca
   readOnly: true
@@ -56,7 +56,7 @@ Define proxy certs volumes
 */}}
 {{- define "pulsar.proxy.certs.volumes" -}}
 {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
-{{- if .Values.tls.proxy.untrustedCa }}
+{{- if .Values.tls.proxy.selfSigned }}
 - name: proxy-ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"

--- a/charts/pulsar/templates/_toolset.tpl
+++ b/charts/pulsar/templates/_toolset.tpl
@@ -44,13 +44,15 @@ Define toolset zookeeper client tls settings
 Define toolset tls certs mounts
 */}}
 {{- define "pulsar.toolset.certs.volumeMounts" -}}
-{{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+{{- if and .Values.tls.enabled (or .Values.tls.zookeeper.enabled .Values.tls.broker.enabled) }}
 - name: toolset-certs
   mountPath: "/pulsar/certs/toolset"
   readOnly: true
+{{- if .Values.tls.broker.untrustedCa }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   mountPath: "/pulsar/keytool/keytool.sh"
@@ -72,12 +74,14 @@ Define toolset tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
+{{- if .Values.tls.broker.untrustedCa }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
+{{- end }}
 {{- if .Values.tls.zookeeper.enabled }}
 - name: keytool
   configMap:

--- a/charts/pulsar/templates/_toolset.tpl
+++ b/charts/pulsar/templates/_toolset.tpl
@@ -66,7 +66,7 @@ Define toolset tls certs volumes
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
 - name: toolset-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
+    secretName: "{{ template "pulsar.toolset.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -74,7 +74,7 @@ Define toolset tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -86,3 +86,14 @@ Define toolset tls certs volumes
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define toolset TLS certificate secret name
+*/}}
+{{- define "pulsar.toolset.tls.secret.name" -}}
+{{- if .Values.tls.toolset.certSecretName -}}
+{{- .Values.tls.toolset.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_toolset.tpl
+++ b/charts/pulsar/templates/_toolset.tpl
@@ -48,7 +48,7 @@ Define toolset tls certs mounts
 - name: toolset-certs
   mountPath: "/pulsar/certs/toolset"
   readOnly: true
-{{- if .Values.tls.broker.untrustedCa }}
+{{- if .Values.tls.broker.selfSigned }}
 - name: ca
   mountPath: "/pulsar/certs/ca"
   readOnly: true
@@ -74,7 +74,7 @@ Define toolset tls certs volumes
       path: tls.crt
     - key: tls.key
       path: tls.key
-{{- if .Values.tls.broker.untrustedCa }}
+{{- if .Values.tls.broker.selfSigned }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
@@ -95,8 +95,8 @@ Define toolset tls certs volumes
 Define toolset TLS certificate secret name
 */}}
 {{- define "pulsar.toolset.tls.secret.name" -}}
-{{- if .Values.tls.toolset.certSecretName -}}
-{{- .Values.tls.toolset.certSecretName -}}
+{{- if .Values.tls.toolset.existingCertSecret -}}
+{{- .Values.tls.toolset.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}
 {{- end -}}

--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -57,3 +57,56 @@ Define zookeeper tls settings
 {{- end }}
 {{- end }}
 
+{{/*
+Define zookeeper certs mounts
+*/}}
+{{- define "pulsar.zookeeper.certs.volumeMounts" -}}
+{{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+- mountPath: "/pulsar/certs/zookeeper"
+  name: zookeeper-certs
+  readOnly: true
+- mountPath: "/pulsar/certs/ca"
+  name: ca
+  readOnly: true
+- name: keytool
+  mountPath: "/pulsar/keytool/keytool.sh"
+  subPath: keytool.sh
+{{- end }}
+{{- end }}
+
+{{/*
+Define zookeeper certs volumes
+*/}}
+{{- define "pulsar.zookeeper.certs.volumes" -}}
+{{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+- name: zookeeper-certs
+  secret:
+    secretName: "{{ template "pulsar.zookeeper.tls.secret.name" . }}"
+    items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+- name: ca
+  secret:
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
+    items:
+      - key: ca.crt
+        path: ca.crt
+- name: keytool
+  configMap:
+    name: "{{ template "pulsar.fullname" . }}-keytool-configmap"
+    defaultMode: 0755
+{{- end}}
+{{- end }}
+
+{{/*
+Define ZooKeeper TLS certificate secret name
+*/}}
+{{- define "pulsar.zookeeper.tls.secret.name" -}}
+{{- if .Values.tls.zookeeper.certSecretName -}}
+{{- .Values.tls.zookeeper.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -65,9 +65,11 @@ Define zookeeper certs mounts
 - mountPath: "/pulsar/certs/zookeeper"
   name: zookeeper-certs
   readOnly: true
+{{- if .Values.tls.zookeeper.untrustedCa }}
 - mountPath: "/pulsar/certs/ca"
   name: ca
   readOnly: true
+{{- end }}
 - name: keytool
   mountPath: "/pulsar/keytool/keytool.sh"
   subPath: keytool.sh
@@ -87,12 +89,14 @@ Define zookeeper certs volumes
         path: tls.crt
       - key: tls.key
         path: tls.key
+{{- if .Values.tls.zookeeper.untrustedCa }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
       - key: ca.crt
         path: ca.crt
+{{- end}}
 - name: keytool
   configMap:
     name: "{{ template "pulsar.fullname" . }}-keytool-configmap"

--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -65,7 +65,7 @@ Define zookeeper certs mounts
 - mountPath: "/pulsar/certs/zookeeper"
   name: zookeeper-certs
   readOnly: true
-{{- if .Values.tls.zookeeper.untrustedCa }}
+{{- if .Values.tls.zookeeper.selfSigned }}
 - mountPath: "/pulsar/certs/ca"
   name: ca
   readOnly: true
@@ -89,7 +89,7 @@ Define zookeeper certs volumes
         path: tls.crt
       - key: tls.key
         path: tls.key
-{{- if .Values.tls.zookeeper.untrustedCa }}
+{{- if .Values.tls.zookeeper.selfSigned }}
 - name: ca
   secret:
     secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
@@ -108,8 +108,8 @@ Define zookeeper certs volumes
 Define ZooKeeper TLS certificate secret name
 */}}
 {{- define "pulsar.zookeeper.tls.secret.name" -}}
-{{- if .Values.tls.zookeeper.certSecretName -}}
-{{- .Values.tls.zookeeper.certSecretName -}}
+{{- if .Values.tls.zookeeper.existingCertSecret -}}
+{{- .Values.tls.zookeeper.existingCertSecret -}}
 {{- else -}}
 {{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}
 {{- end -}}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -247,16 +247,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
-          {{- if .Values.tls.proxy.enabled }}
-          - mountPath: "/pulsar/certs/proxy"
-            name: proxy-certs
-            readOnly: true
-          {{- end}}
-          {{- if .Values.tls.enabled }}
-          - mountPath: "/pulsar/certs/ca"
-            name: ca
-            readOnly: true
-          {{- end}}
+          {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
           {{- if .Values.proxy.extraVolumeMounts }}
 {{ toYaml .Values.proxy.extraVolumeMounts | indent 10 }}
           {{- end }}
@@ -293,21 +284,6 @@ spec:
                 path: proxy/token
         {{- end}}
         {{- end}}
-        {{- if .Values.tls.proxy.enabled }}
-        - name: ca
-          secret:
-            secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
-            items:
-              - key: ca.crt
-                path: ca.crt
-        - name: proxy-certs
-          secret:
-            secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
-            items:
-              - key: tls.crt
-                path: tls.crt
-              - key: tls.key
-                path: tls.key
-        {{- end}}
+        {{- include "pulsar.proxy.certs.volumes" . | nindent 6 }}
       {{- end}}
 {{- end }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -247,7 +247,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- end }}
-          {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 8 }}
+          {{- include "pulsar.proxy.certs.volumeMounts" . | nindent 8 }}
           {{- if .Values.proxy.extraVolumeMounts }}
 {{ toYaml .Values.proxy.extraVolumeMounts | indent 10 }}
           {{- end }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -219,17 +219,7 @@ spec:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.datalog.name }}"
           mountPath: /pulsar/data-log
         {{- end }}
-        {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-        - mountPath: "/pulsar/certs/zookeeper"
-          name: zookeeper-certs
-          readOnly: true
-        - mountPath: "/pulsar/certs/ca"
-          name: ca
-          readOnly: true
-        - name: keytool
-          mountPath: "/pulsar/keytool/keytool.sh"
-          subPath: keytool.sh
-        {{- end }}
+        {{- include "pulsar.zookeeper.certs.volumeMounts" . | nindent 8 }}
         {{- if .Values.zookeeper.extraVolumeMounts }}
 {{ toYaml .Values.zookeeper.extraVolumeMounts | indent 8 }}
         {{- end }}
@@ -241,26 +231,7 @@ spec:
       {{- if .Values.zookeeper.extraVolumes }}
 {{ toYaml .Values.zookeeper.extraVolumes | indent 6 }}
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-      - name: zookeeper-certs
-        secret:
-          secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
-          items:
-            - key: tls.crt
-              path: tls.crt
-            - key: tls.key
-              path: tls.key
-      - name: ca
-        secret:
-          secretName: "{{ .Release.Name }}-{{ .Values.tls.ca_suffix }}"
-          items:
-            - key: ca.crt
-              path: ca.crt
-      - name: keytool
-        configMap:
-          name: "{{ template "pulsar.fullname" . }}-keytool-configmap"
-          defaultMode: 0755
-      {{- end}}
+      {{- include "pulsar.zookeeper.certs.volumes" . | nindent 6 }}
       {{- include "pulsar.imagePullSecrets" . | nindent 6}}
 {{- if and (and .Values.persistence .Values.volumes.persistence) .Values.zookeeper.volumes.persistence }}
   volumeClaimTemplates:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -228,29 +228,48 @@ tls:
     keySize: 4096
     keyAlgorithm: RSA
     keyEncoding: PKCS8
+    caSecretName:
   # settings for generating certs for proxy
   proxy:
     enabled: false
     cert_name: tls-proxy
     createCert: true  # set to false if you want to use an existing certificate
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # settings for generating certs for broker
   broker:
     enabled: false
     cert_name: tls-broker
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # settings for generating certs for bookies
   bookie:
     enabled: false
     cert_name: tls-bookie
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # settings for generating certs for zookeeper
   zookeeper:
     enabled: false
     cert_name: tls-zookeeper
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # settings for generating certs for recovery
   autorecovery:
     cert_name: tls-recovery
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # settings for generating certs for toolset
   toolset:
     cert_name: tls-toolset
+    # specify name of secret contain certificate if using pre-generated certificate
+    certSecretName:
+    untrustedCa: true
   # TLS setting for function runtime instance
   function_instance:
     # controls the use of TLS for function runtime connections towards brokers

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -228,6 +228,7 @@ tls:
     keySize: 4096
     keyAlgorithm: RSA
     keyEncoding: PKCS8
+    # specify name of ca secret if using pre-generated certificate
     caSecretName:
   # settings for generating certs for proxy
   proxy:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -228,47 +228,52 @@ tls:
     keySize: 4096
     keyAlgorithm: RSA
     keyEncoding: PKCS8
-    # specify name of ca secret if using pre-generated certificate
+    # specify name of the existing CA secret. This is required if using the self-signed certificates.
     existingCaSecret:
   # settings for generating certs for proxy
   proxy:
     enabled: false
     cert_name: tls-proxy
     createCert: true  # set to false if you want to use an existing certificate
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
     selfSigned: true
   # settings for generating certs for broker
   broker:
     enabled: false
     cert_name: tls-broker
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
     selfSigned: true
   # settings for generating certs for bookies
   bookie:
     enabled: false
     cert_name: tls-bookie
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
     selfSigned: true
   # settings for generating certs for zookeeper
   zookeeper:
     enabled: false
     cert_name: tls-zookeeper
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
     selfSigned: true
   # settings for generating certs for recovery
   autorecovery:
     cert_name: tls-recovery
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
     selfSigned: true
   # settings for generating certs for toolset
   toolset:
     cert_name: tls-toolset
-    # specify name of secret contain certificate if using pre-generated certificate
+    # specify name of the existing certificate secret.
     existingCertSecret:
   # TLS setting for function runtime instance
   function_instance:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -229,48 +229,47 @@ tls:
     keyAlgorithm: RSA
     keyEncoding: PKCS8
     # specify name of ca secret if using pre-generated certificate
-    caSecretName:
+    existingCaSecret:
   # settings for generating certs for proxy
   proxy:
     enabled: false
     cert_name: tls-proxy
     createCert: true  # set to false if you want to use an existing certificate
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
+    selfSigned: true
   # settings for generating certs for broker
   broker:
     enabled: false
     cert_name: tls-broker
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
+    selfSigned: true
   # settings for generating certs for bookies
   bookie:
     enabled: false
     cert_name: tls-bookie
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
+    selfSigned: true
   # settings for generating certs for zookeeper
   zookeeper:
     enabled: false
     cert_name: tls-zookeeper
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
+    selfSigned: true
   # settings for generating certs for recovery
   autorecovery:
     cert_name: tls-recovery
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
+    selfSigned: true
   # settings for generating certs for toolset
   toolset:
     cert_name: tls-toolset
     # specify name of secret contain certificate if using pre-generated certificate
-    certSecretName:
-    untrustedCa: true
+    existingCertSecret:
   # TLS setting for function runtime instance
   function_instance:
     # controls the use of TLS for function runtime connections towards brokers

--- a/examples/values-existing-certificates.yaml
+++ b/examples/values-existing-certificates.yaml
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# enable TLS
+tls:
+  enabled: true
+  common:
+    # specify name of the existing CA secret. This is required if using the self-signed certificates.
+    existingCaSecret: pulsar-ca-tls
+  proxy:
+    enabled: true
+    # specify name of the existing certificate secret.
+    existingCertSecret: proxy-tls-cert
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
+    selfSigned: true
+  # settings for generating certs for broker
+  broker:
+    enabled: true
+    # specify name of the existing certificate secret.
+    existingCertSecret: broker-tls-cert
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
+    selfSigned: true
+  # settings for generating certs for bookies
+  bookie:
+    enabled: true
+    # specify name of the existing certificate secret.
+    existingCertSecret: bookie-tls-cert
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
+    selfSigned: true
+  # settings for generating certs for zookeeper
+  zookeeper:
+    enabled: true
+    # specify name of the existing certificate secret.
+    existingCertSecret: zookeeper-tls-cert
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
+    selfSigned: true
+  # settings for generating certs for recovery
+  autorecovery:
+    # specify name of the existing certificate secret.
+    existingCertSecret: autorecovery-tls-cert
+    # using self-signed existing certificate. If selfSigned is true, please note that tls.existingCaSecret should be configured. 
+    selfSigned: true
+  # settings for generating certs for toolset
+  toolset:
+    # specify name of the existing certificate secret.
+    existingCertSecret: toolset-tls-cert


### PR DESCRIPTION
Fixes #<xyz>

### Motivation

To support the scenario that users have pre-generated tls certificates. Case like users have existing certificate secrets created by cert-manager or by manual, with this PR we can allow the zk, bk, broker, proxy and toolset to use the pre-generated secrets. 

### Modifications

In the values, we add several new fields:
* `tls.common.caSecretName`: the pre-generated ca certificate, only used when the `untrustedCa` equals `true`
* `tls.component.certSecretName`: the pre-generated tls certificate for each component. 
* `tls.component.untrustedCa`: untrustedCa means the selfsigned, and will require the caSecret. 
### Verifying this change

- [x] Make sure that the change passes the CI checks.
