### PR TITLE
Use Pulsar 4.0.2 image by default

### DIFF
--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "4.0.1"
+appVersion: "4.0.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.8.0


### PR DESCRIPTION
### Motivation

Pulsar 4.0.2 has been released

### Modifications

Bump appVersion to 4.0.2 so that Pulsar 4.0.2 image is used by default.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
