### PR TITLE
Fix OOM issue on broker wait-zookeeper-ready initContainer

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -138,7 +138,7 @@ spec:
         args:
           - >-
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
-            export BOOKIE_MEM="-Xmx128M";
+            export PULSAR_MEM="-Xmx128M";
             {{- if .Values.pulsar_metadata.configurationStore }}
             until timeout 15 bin/pulsar zookeeper-shell -server {{ template "pulsar.configurationStore.connect" . }} get {{ .Values.configurationStoreMetadataPrefix }}/admin/clusters/{{ template "pulsar.cluster.name" . }}; do
             {{- end }}


### PR DESCRIPTION
### Motivation

Getting OOM issues on broker startup in the wait-zookeeper-ready initContainer:
```
pulsar cluster stellar-pulsar isn't initialized yet ... check in 3 seconds ...                                                                                                                                                         
[1.007s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[1.694s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.282s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.785s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[3.086s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[3.086s][error][gc] Forced to lower max Java heap size from 2048M(100%) to 1508M(74%)                                                                                                                                                  
[3.086s][error][gc] Failed to allocate initial Java heap (2048M)                                                                                                                                                                       
Error: Could not create the Java Virtual Machine.                                                                                                                                                                                      
Error: A fatal exception has occurred. Program will exit.                                                                                                                                                                              
pulsar cluster stellar-pulsar isn't initialized yet ... check in 3 seconds ...                                                                                                                                                         
[1.114s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[1.738s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.111s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.421s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.762s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.762s][error][gc] Forced to lower max Java heap size from 2048M(100%) to 1508M(74%)                                                                                                                                                  
[2.762s][error][gc] Failed to allocate initial Java heap (2048M)                                                                                                                                                                       
Error: Could not create the Java Virtual Machine.                                                                                                                                                                                      
Error: A fatal exception has occurred. Program will exit.                                                                                                                                                                              
pulsar cluster stellar-pulsar isn't initialized yet ... check in 3 seconds ...                                                                                                                                                         
[1.082s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[1.707s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.067s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.354s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.644s][error][gc] Failed to commit memory (Not enough space)                                                                                                                                                                         
[2.644s][error][gc] Forced to lower max Java heap size from 2048M(100%) to 1508M(74%)                                                                                                                                                  
[2.644s][error][gc] Failed to allocate initial Java heap (2048M)                                                                                                                                                                       
Error: Could not create the Java Virtual Machine.                                                                                                                                                                                      
Error: A fatal exception has occurred. Program will exit. 
Killed
```

### Modifications

Looks like the check to see if zookeeper is running mistakenly has set the `BOOKIE_MEM` env var when it should be setting `PULSAR_MEM` instead.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] Tested on live env
