### PR TITLE
[fix] Fix broker service annotations issue, add annotations support to autorecovery service and make handling consistent

### DIFF
--- a/charts/pulsar/templates/autorecovery-service.yaml
+++ b/charts/pulsar/templates/autorecovery-service.yaml
@@ -26,6 +26,10 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}
+{{- with .Values.autorecovery.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: http

--- a/charts/pulsar/templates/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper-service.yaml
@@ -26,9 +26,9 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}
-{{- if .Values.bookkeeper.service.annotations }}
+{{- with .Values.bookkeeper.service.annotations }}
   annotations:
-{{ toYaml .Values.bookkeeper.service.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -26,7 +26,7 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}
-{{- with .Values.broker.service_account.annotations }}
+{{- with .Values.broker.service.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager-service.yaml
@@ -26,8 +26,10 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
+{{- with .Values.pulsar_manager.service.annotations }}
   annotations:
-{{ toYaml .Values.pulsar_manager.service.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.pulsar_manager.service.type }}
   {{- if .Values.pulsar_manager.service.externalTrafficPolicy }}
@@ -58,8 +60,10 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}
+{{- with .Values.pulsar_manager.adminService.annotations }}
   annotations:
-{{ toYaml .Values.pulsar_manager.adminService.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.pulsar_manager.adminService.type }}
   ports:

--- a/charts/pulsar/templates/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper-service.yaml
@@ -28,7 +28,10 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
-{{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
+{{- with .Values.zookeeper.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   ports:
     # prometheus needs to access /metrics endpoint

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -833,6 +833,10 @@ autorecovery:
     requests:
       memory: 64Mi
       cpu: 0.05
+  ## Bookkeeper auto-recovery service
+  ## templates/autorecovery-service.yaml
+  service:
+    annotations: {}
   ## Bookkeeper auto-recovery service account
   ## templates/autorecovery-service-account.yaml
   service_account:


### PR DESCRIPTION
Fixes #573

### Motivation

See #573

### Modifications

- Fix broker service annotations issue
- Add annotations support to autorecovery service which was missing
- Consistenly use similar way to handle annotations

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
