### PR TITLE
Upgrade to Pulsar 4.0.3

### DIFF
--- a/.ci/clusters/values-pulsar-previous-lts.yaml
+++ b/.ci/clusters/values-pulsar-previous-lts.yaml
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-defaultPulsarImageTag: 3.0.9
+defaultPulsarImageTag: 3.0.10

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "4.0.2"
+appVersion: "4.0.3"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 3.9.0


### PR DESCRIPTION
- bump appVersion to 4.0.3
- bump defaultPulsarImageTag to 3.0.10 in CI test for values-pulsar-previous-lts since 3.0.10 was also released