### PR TITLE
Workaround issue with Prometheus 3.0 and metrics

### DIFF
--- a/charts/pulsar/templates/autorecovery-podmonitor.yaml
+++ b/charts/pulsar/templates/autorecovery-podmonitor.yaml
@@ -30,6 +30,8 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: recovery
+  # workaround for https://github.com/apache/bookkeeper/pull/4208  
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http
       path: /metrics

--- a/charts/pulsar/templates/autorecovery-podmonitor.yaml
+++ b/charts/pulsar/templates/autorecovery-podmonitor.yaml
@@ -30,7 +30,6 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: recovery
-  # workaround for https://github.com/apache/bookkeeper/pull/4208  
   fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http

--- a/charts/pulsar/templates/bookkeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/bookkeeper-podmonitor.yaml
@@ -30,6 +30,8 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: bookie
+  # workaround for https://github.com/apache/bookkeeper/pull/4208  
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http
       path: /metrics

--- a/charts/pulsar/templates/bookkeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/bookkeeper-podmonitor.yaml
@@ -30,7 +30,6 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: bookie
-  # workaround for https://github.com/apache/bookkeeper/pull/4208  
   fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http

--- a/charts/pulsar/templates/broker-podmonitor.yaml
+++ b/charts/pulsar/templates/broker-podmonitor.yaml
@@ -30,6 +30,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: broker
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http
       path: /metrics

--- a/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
@@ -30,6 +30,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: oxia-coordinator
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: metrics
       path: /metrics

--- a/charts/pulsar/templates/oxia-server-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-server-podmonitor.yaml
@@ -30,6 +30,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: oxia-server
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: metrics
       path: /metrics

--- a/charts/pulsar/templates/proxy-podmonitor.yaml
+++ b/charts/pulsar/templates/proxy-podmonitor.yaml
@@ -30,6 +30,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: proxy
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http
       path: /metrics

--- a/charts/pulsar/templates/zookeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/zookeeper-podmonitor.yaml
@@ -31,6 +31,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   jobLabel: zookeeper
+  fallbackScrapeProtocol: PrometheusText0.0.4
   podMetricsEndpoints:
     - port: http
       path: /metrics


### PR DESCRIPTION
Fixes #555 

### Motivation

See #555

### Modifications

Specify `PrometheusText0.0.4` as `fallbackScrapeProtocol` for Prometheus v2 compatibility for all podmonitors.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
