### PR TITLE
Restore support for dbStorage_rocksDB_* settings defined in bookkeeper.configData

### DIFF
--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,5 +61,19 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
+  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
+  # Set RocksDB default format version to 5
+  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
+  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
+  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
+  {{- else }}
+  # Specify existing files to load RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
+  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,6 +728,10 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
+  ## Use RocksDB config in configData
+  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
+  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
+  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##


### PR DESCRIPTION
### Motivation

- https://github.com/apache/bookkeeper/pull/3056 changed the way how Bookkeeper's RocksDB parameters are configured
- https://github.com/apache/bookkeeper/pull/3523 restores the support, but the code doesn't work as expected unless it's configured properly
- RocksDB format version defaults to 2 with 4.17 branch which is not a great default

### Modifications

- add new config bookkeeper.useRocksDBConfigInConfigData which defaults to `true`
- This will configure bookkeeper so that the dbStorage_rocksDB_* settings defined in bookkeeper.configData will be used
- Set RocksDB format version for new db files to 5 which will enable certain RocksDB performance optimizations.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
