### PR TITLE
Revisit solution to configure Bookkeeper RocksDB settings using individual RocksDB config files

### DIFF
--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,19 +61,5 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
-  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
-  # Set RocksDB default format version to 5
-  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
-  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
-  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
-  {{- else }}
-  # Specify existing files to load RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
-  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -177,9 +177,25 @@ spec:
         command: ["sh", "-c"]
         args:
         - |
-        {{- if .Values.bookkeeper.additionalCommand }}
+          # set required environment variables to use rocksdb config files provided in the Pulsar image
+          export PULSAR_PREFIX_defaultRocksdbConf=${PULSAR_PREFIX_defaultRocksdbConf:-conf/default_rocksdb.conf}
+          export PULSAR_PREFIX_entryLocationRocksdbConf=${PULSAR_PREFIX_entryLocationRocksdbConf:-conf/entry_location_rocksdb.conf}
+          export PULSAR_PREFIX_ledgerMetadataRocksdbConf=${PULSAR_PREFIX_ledgerMetadataRocksdbConf:-conf/ledger_metadata_rocksdb.conf}
+          if [ -x bin/update-rocksdb-conf-from-env.py ] && [ -f "${PULSAR_PREFIX_entryLocationRocksdbConf}" ]; then
+            echo "Updating ${PULSAR_PREFIX_entryLocationRocksdbConf} from environment variables starting with dbStorage_rocksDB_*"
+            bin/update-rocksdb-conf-from-env.py "${PULSAR_PREFIX_entryLocationRocksdbConf}"
+          else
+            # Ensure that Bookkeeper will not load RocksDB config from existing files and fallback to use default RocksDB config
+            # See https://github.com/apache/bookkeeper/pull/3523 as reference
+            export PULSAR_PREFIX_defaultRocksdbConf=conf/non_existing_default_rocksdb.conf
+            export PULSAR_PREFIX_entryLocationRocksdbConf=conf/non_existing_entry_location_rocksdb.conf
+            export PULSAR_PREFIX_ledgerMetadataRocksdbConf=conf/non_existing_ledger_metadata_rocksdb.conf
+            # Ensure that Bookkeeper will use RocksDB format_version 5 (this currently applies only to the entry location rocksdb due to a bug in Bookkeeper)
+            export PULSAR_PREFIX_dbStorage_rocksDB_format_version=${PULSAR_PREFIX_dbStorage_rocksDB_format_version:-5}
+          fi
+          {{- if .Values.bookkeeper.additionalCommand }}
           {{ .Values.bookkeeper.additionalCommand }}
-        {{- end }}
+          {{- end }}
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,10 +728,6 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
-  ## Use RocksDB config in configData
-  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
-  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
-  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##


### PR DESCRIPTION
### Motivation

Follow-up on #580

Pulsar has provided individual RocksDB config files to configure BookKeeper's RocksDB databases.
However, this configuration hasn't been consistently used since Pulsar's bookkeeper.conf doesn't contain `defaultRocksdbConf`, `entryLocationRocksdbConf` and `ledgerMetadataRocksdbConf` files.

Related BookKeeper changes:
- https://github.com/apache/bookkeeper/pull/3056 in 4.15.0
- https://github.com/apache/bookkeeper/pull/3523 in 4.15.3 / 4.16.0

Related Pulsar changes:
- https://github.com/apache/pulsar/pull/15142
- https://github.com/apache/pulsar/pull/21157
- https://github.com/apache/pulsar/pull/23175
- https://github.com/apache/pulsar/pull/23178

### Modifications

- enable configuration so that the RockDB config files really get used.
- use `bin/update-rocksdb-conf-from-env.py` script to apply `dbStorage_rocksDB_*` environment variables to update the config files

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
