### PR TITLE
Add Broker Cache and Sockets dashboards

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1498,6 +1498,12 @@ kube-prometheus-stack:
         offloader:
           url: https://raw.githubusercontent.com/apache/pulsar/refs/heads/master/grafana/dashboards/offloader.json
           datasource: Prometheus
+        broker-cache:
+          url: https://raw.githubusercontent.com/datastax/pulsar-helm-chart/refs/heads/master/helm-chart-sources/pulsar/grafana-dashboards/broker-cache-by-broker.json
+          datasource: Prometheus
+        sockets:
+          url: https://raw.githubusercontent.com/datastax/pulsar-helm-chart/refs/heads/master/helm-chart-sources/pulsar/grafana-dashboards/sockets.json
+          datasource: Prometheus
   ## Prometheus node exporter component
   prometheus-node-exporter:
     enabled: true


### PR DESCRIPTION
### Motivation

- The broker cache dash board will provide observatibility into Pulsar's managed ledger cache and help tune it
- Sockets dash board will help detect issues related to hanging connections or file handle resource leaks

### Modifications

- add configuration to values.yaml for pre-loaded dashboards. These dashboards are from a Apache 2.0 licensed repository.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
