### PR TITLE
Change Pulsar Proxy service load balancer type to ClusterIP

### DIFF
--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -28,6 +28,7 @@ TLS=${TLS:-"false"}
 SYMMETRIC=${SYMMETRIC:-"false"}
 FUNCTION=${FUNCTION:-"false"}
 MANAGER=${MANAGER:-"false"}
+ALLOW_LOADBALANCERS=${ALLOW_LOADBALANCERS:-"false"}
 
 source ${PULSAR_HOME}/.ci/helm.sh
 
@@ -56,6 +57,7 @@ fi
 install_type="install"
 test_action="produce-consume"
 if [[ "$UPGRADE_FROM_VERSION" != "" ]]; then
+    ALLOW_LOADBALANCERS="true"
     # install older version of pulsar chart
     PULSAR_CHART_VERSION="$UPGRADE_FROM_VERSION"
     ci::install_pulsar_chart install ${PULSAR_HOME}/.ci/values-common.yaml ${PULSAR_HOME}/${VALUES_FILE} "${extra_opts[@]}"
@@ -82,6 +84,11 @@ ci::install_pulsar_chart ${install_type} ${PULSAR_HOME}/.ci/values-common.yaml $
 
 echo "Wait 10 seconds"
 sleep 10
+
+# check that there aren't any loadbalancers if ALLOW_LOADBALANCERS is false
+if [[ "${ALLOW_LOADBALANCERS}" == "false" ]]; then
+    ci::check_loadbalancers
+fi
 
 # check pulsar environment
 ci::check_pulsar_environment

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -424,6 +424,18 @@ function ci::test_pulsar_manager() {
   fi
 }
 
+function ci::check_loadbalancers() {
+  (
+  set +e
+  ${KUBECTL} get services -n ${NAMESPACE} | grep LoadBalancer
+  if [ $? -eq 0 ]; then
+    echo "Error: Found service with type LoadBalancer. This is not allowed because of security reasons."
+    exit 1
+  fi
+  exit 0
+  )
+}
+
 function ci::validate_kustomize_yaml() {
   # if kustomize is not installed, install kustomize to a temp directory
   if ! command -v kustomize &> /dev/null; then

--- a/charts/pulsar/templates/NOTES.txt
+++ b/charts/pulsar/templates/NOTES.txt
@@ -1,18 +1,185 @@
+======================================================================================
+                           APACHE PULSAR HELM CHART
+======================================================================================
+
+======================================================================================
+                           SECURITY ADVISORY
+======================================================================================
+
+This Helm chart's default configuration DOES NOT meet production security requirements.
+Users MUST review and customize security settings for their specific environment.
+
+IMPORTANT: This Helm chart provides a starting point for Pulsar deployments but requires
+significant security customization before use in production environments. We strongly
+recommend implementing:
+
+1. Proper network isolation and access controls
+2. Authentication and authorization for all components
+3. TLS encryption for all communication channels
+4. Regular security updates and vulnerability assessments
+
+As an open source project, we welcome contributions to improve security features.
+Please consider submitting pull requests to address security gaps or enhance
+existing security implementations.
+
+---------------------------------------------------------------------------------------
+
+SECURITY NOTICE: The Pulsar proxy is not designed for direct public internet exposure.
+It lacks security features required for untrusted networks and should only be deployed
+within secured environments with proper network controls.
+
+IMPORTANT CHANGE IN v4.0.0: Default service type changed from LoadBalancer to ClusterIP
+for security reasons. This limits access to within the Kubernetes environment by default.
+
+---------------------------------------------------------------------------------------
+IF YOU NEED EXTERNAL ACCESS FOR YOUR PULSAR CLUSTER:
+---------------------------------------------------------------------------------------
+
+Note: This information might be outdated. Please go to https://github.com/apache/pulsar-helm-chart for updated information.
+
+If you need to expose the Pulsar Proxy outside the cluster using a LoadBalancer service type:
+
+1. USE INTERNAL LOAD BALANCERS ONLY
+   - Set type to LoadBalancer only in secured environments with proper network controls
+   - Add cloud provider-specific annotations for internal load balancers
+   - See cloud provider documentation:
+     * AWS / EKS: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/
+     * Azure / AKS: https://learn.microsoft.com/en-us/azure/aks/internal-lb
+     * GCP / GKE: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters
+   - Examples (verify correctness for your environment):
+     * AWS / EKS:  service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+     * Azure / AKS: service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+     * GCP / GKE:   networking.gke.io/load-balancer-type: "Internal"
+
+2. IMPLEMENT AUTHENTICATION AND AUTHORIZATION
+   - Configure all clients to authenticate properly
+   - Set up appropriate authorization policies
+
+3. USE TLS FOR ALL CONNECTIONS
+   - Enable TLS for client-to-proxy connections
+   - Enable TLS for proxy-to-broker connections
+   - Enable TLS for all internal cluster communications (brokers, zookeepers, bookies)
+   - Note: TLS alone is NOT sufficient as a security solution in Pulsar. Even with TLS enabled,
+     clusters exposed to untrusted networks remain vulnerable to denial-of-service attacks, 
+     authentication bypass attempts, and protocol-level exploits. Always implement defense-in-depth
+     security measures and limit exposure to trusted networks only.
+
+4. NETWORK SECURITY
+   - Use private networks (VPCs)
+   - Configure firewalls, security groups, and IP restrictions appropriately
+   - In addition, consider using loadBalancerSourceRanges to limit access to specific IP ranges
+
+5. CLIENT IP ADDRESS BASED ACCESS RESTRICTIONS
+   - When using a LoadBalancer service type, restrict access to specific IP ranges by configuring 
+     `proxy.service.loadBalancerSourceRanges` in your values.yaml
+   - Important: This should be implemented alongside other security measures (internal load balancer,
+     authentication, TLS, network policies) as part of a defense-in-depth strategy,
+     not as a standalone security solution
+
+---------------------------------------------------------------------------------------
+ALTERNATIVE FOR EXTERNAL ACCESS
+---------------------------------------------------------------------------------------
+
+As an alternative method for external access, Pulsar has support for SNI proxy routing:
+https://pulsar.apache.org/docs/next/concepts-proxy-sni-routing/
+SNI Proxy routing is supported with proxy servers such as Apache Traffic Server, HAProxy and Nginx.
+
+Note: This option isn't currently implemented in the Apache Pulsar Helm chart.
+
+IMPORTANT: Pulsar binary protocol cannot be exposed outside of the Kubernetes cluster
+using Kubernetes Ingress. Kubernetes Ingress works for the Admin REST API and topic lookups,
+but clients would be connecting to the advertised listener addresses returned by the brokers and it 
+would only work when clients can connect directly to brokers. This is not a supported secure option 
+for exposing Pulsar to untrusted networks.
+
+{{- if .Values.useReleaseStatus }}
+
+======================================================================================
+                           🚀 QUICK START 🚀
+======================================================================================
+
+Watching events to view progress of deployment:
+kubectl get -n {{ .Values.namespace | default .Release.Namespace }} events -o wide --watch
+
+Watching state of deployed Kubernetes objects, updated every 2 seconds:
+watch kubectl get -n  {{ .Values.namespace | default .Release.Namespace }} all
+
+{{- if .Values.components.proxy }}
+
+Waiting until Pulsar Proxy is available:
+kubectl wait --timeout=600s --for=condition=ready pod -n {{ .Values.namespace | default .Release.Namespace }} -l component=proxy
+{{- end }}
+
+Watching state with k9s (https://k9scli.io/topics/install/):
+k9s -n {{ .Values.namespace | default .Release.Namespace }}
+
+{{- if and .Values.affinity.anti_affinity (or (gt (int .Values.bookkeeper.replicaCount) 1) (gt (int .Values.zookeeper.replicaCount) 1)) }}
+
+======================================================================================
+                      ⚠️  NOTICE FOR DEV K8S CLUSTER USERS  ⚠️
+======================================================================================
+
+Please note that anti-affinity rules for Zookeeper and Bookie components require at least 
+one node per replica. There are currently {{ .Values.bookkeeper.replicaCount }} bookies and {{ .Values.zookeeper.replicaCount }} zookeepers configured.
+
+For Kubernetes clusters with fewer than 3 nodes, such as single-node Kubernetes clusters in 
+development environments like minikube, Docker Desktop, Rancher Desktop (k3s), or Podman 
+Desktop, you must disable the anti-affinity feature by either:
+
+Adding to your values.yaml:
+affinity:
+  anti_affinity: false
+
+Or adding "--set affinity.anti_affinity=false" to the helm command line.
+
+After making the changes to your values yaml file, redeploy with "helm upgrade":
+helm upgrade -n {{ .Release.Namespace }} -f your_values_file.yaml {{ .Release.Name }} apachepulsar/pulsar
+
+These configuration instructions can be omitted for Kubernetes clusters with 3 or more nodes.
+{{- end }}
+{{- end }}
+{{- if and (eq .Values.proxy.service.type "LoadBalancer") (not .Values.proxy.service.annotations) }}
+
+======================================================================================
+                      ⚠️ 🚨 INSECURE CONFIGURATION DETECTED 🚨 ⚠️
+======================================================================================
+WARNING: You are using a LoadBalancer service type without internal load balancer
+annotations. This is potentially an insecure configuration. Please carefully review
+the security recommendations above and visit https://github.com/apache/pulsar-helm-chart
+for more information.
+======================================================================================
+{{- end }}
+
+======================================================================================
+                           DISCLAIMER
+======================================================================================
+
+The providers of this Helm chart make no guarantees regarding the security of the chart under
+any circumstances. It is the user's responsibility to ensure that their deployment is secure
+and complies with all relevant security standards and regulations.
+
+By using this Helm chart, the user acknowledges the risks associated with its default
+configuration and the necessity for proper security customization. The user further 
+agrees that the providers of the Helm chart shall not be liable for any security breaches
+or incidents resulting from the use of the chart.
+
+The user assumes full responsibility for the security and integrity of their deployment.
+This includes, but is not limited to, the proper configuration of security features and 
+adherence to best practices for securing network access. The providers of this Helm chart
+disclaim all warranties, whether express or implied, including any warranties of
+merchantability, fitness for a particular purpose, and non-infringement of third-party rights.
+
+======================================================================================
+                           RESOURCES
+======================================================================================
+
+- 🖥️ Install k9s terminal interface for viewing and managing k8s clusters: https://k9scli.io/topics/install/
+- ❓ Usage Questions: https://github.com/apache/pulsar/discussions/categories/q-a
+- 🐛 Report Issues: https://github.com/apache/pulsar-helm-chart/issues
+- 🔒 Security Issues: https://pulsar.apache.org/security/
+- 📚 Documentation: https://github.com/apache/pulsar-helm-chart
+
+🌟 Please contribute to improve the Apache Pulsar Helm chart and its documentation:
+- 🤝 Contribute: https://github.com/apache/pulsar-helm-chart
+
 Thank you for installing Apache Pulsar Helm chart version {{ .Chart.Version }}.
-
-!! WARNING !!
-
-Important Security Disclaimer for Apache Pulsar Helm Chart Usage:
-
-This Helm chart is provided with a default configuration that does not
-meet the security requirements for production environments or sensitive
-data handling. Users are strongly advised to thoroughly review and
-customize the security settings to ensure a secure deployment that
-aligns with their specific operational and security policies.
-
-Go to https://github.com/apache/pulsar-helm-chart for more details.
-
-Ask usage questions at https://github.com/apache/pulsar/discussions/categories/q-a
-Report issues to https://github.com/apache/pulsar-helm-chart/issues
-Please contribute improvements to https://github.com/apache/pulsar-helm-chart
-

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -21,9 +21,14 @@
 ### K8S Settings
 ###
 
-### Namespace to deploy pulsar
-# The namespace to use to deploy the pulsar components, if left empty
-# will default to .Release.Namespace (aka helm --namespace).
+### Namespace to deploy Pulsar
+### Note: Prefer using helm's --namespace flag with --create-namespace instead
+## The namespace to use to deploy the Pulsar components. If left empty,
+## it will default to .Release.Namespace (aka helm --namespace).
+## Please note that kube-prometheus-stack will not be able to scrape Pulsar component metrics by default unless
+## it is deployed in the same namespace as Pulsar. The kube-prometheus-stack namespace can be configured by setting
+## the kube-prometheus-stack.namespaceOverride key to match Pulsar's namespace.
+## More details are provided in the comments for the kube-prometheus-stack.namespaceOverride key later in this file.
 namespace: ""
 namespaceCreate: false
 
@@ -35,6 +40,7 @@ clusterDomain: cluster.local
 ###
 
 ## Set to true on install
+## There's no need to set this value unless you're using a system that doesn't track .Release.IsInstall or .Release.IsUpgrade (like argocd)
 initialize: false
 ## Set useReleaseStatus to false if you're deploying this chart using a system that doesn't track .Release.IsInstall or .Release.IsUpgrade (like argocd)
 useReleaseStatus: true
@@ -90,9 +96,8 @@ volumes:
 
 rbac:
   enabled: false
-  psp: false
+  psp: false  # DEPRECATED: PodSecurityPolicy is not supported in Kubernetes 1.25+
   limit_to_namespace: true
-
 
 ## AntiAffinity
 ##
@@ -101,6 +106,8 @@ rbac:
 ## If you need to disable AntiAffinity for a component, you can set
 ## the `affinity.anti_affinity` settings to `false` for that component.
 affinity:
+  ## When set to true, the scheduler will try to spread pods across different nodes.
+  ## It is necessary to set this to false if you're using a Kubernetes cluster with less than 3 nodes, such as local development environments.
   anti_affinity: true
   # Set the anti affinity type. Valid values:
   # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
@@ -1318,8 +1325,48 @@ proxy:
       http: 8080
       https: 8443
   service:
-    annotations: {}
-    type: LoadBalancer
+    # Service type defaults to ClusterIP for security reasons.
+    #
+    # SECURITY NOTICE: The Pulsar proxy is not designed for direct public internet exposure
+    # (see https://pulsar.apache.org/docs/4.0.x/administration-proxy/).
+    #
+    # If you need to expose the proxy outside of the cluster using a LoadBalancer service type:
+    # 1. Set type to LoadBalancer only in secured environments with proper network controls.
+    #    In cloud managed Kubernetes clusters, make sure to add annotations to the service to create an
+    #    internal load balancer so that the load balancer is not exposed to the public internet.
+    #    You must also ensure that the configuration is correct so that the load balancer is not exposed to the public internet.
+    # 2. Configure authentication and authorization
+    # 3. Use TLS for all connections
+    # 4. If you are exposing to unsecure networks, implement additional security measures like
+    #    IP restrictions (loadBalancerSourceRanges)
+    #
+    # Please notice that the the Apache Pulsar project takes no responsibility for any security issues
+    # for your deployment. Exposing the cluster using Pulsar Proxy to unsecure networks is not supported.
+    #
+    # Previous chart versions defaulted to LoadBalancer which could create security risks.
+    type: ClusterIP
+    # When using a LoadBalancer service type, add internal load balancer annotations to the service to create an internal load balancer.
+    annotations: {
+      ## Set internal load balancer annotations when using a LoadBalancer service type because of security reasons.
+      ## You must also ensure that the configuration is correct so that the load balancer is not exposed to the public internet.
+      ## This information below is for reference only and may not be applicable to your cloud provider.
+      ## Please refer to the cloud provider's documentation for the correct annotations.
+      ## Kubernetes documentation about internal load balancers
+      ## https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+      ## AWS / EKS
+      ## Ensure that you have recent AWS Load Balancer Controller installed.
+      ## Docs: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/
+      # service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      ## Azure / AKS
+      ## Docs: https://learn.microsoft.com/en-us/azure/aks/internal-lb
+      # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      ## GCP / GKE
+      ## Docs: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters
+      # networking.gke.io/load-balancer-type: "Internal"
+      ## Allow global access to the internal load balancer when needed.
+      # networking.gke.io/internal-load-balancer-allow-global-access: "true"
+    }
+
     ## Optional. Leave it blank to get next available random IP.
     loadBalancerIP: ""
     ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
@@ -1419,6 +1466,12 @@ toolset:
 kube-prometheus-stack:
   ## Enable the kube-prometheus-stack chart
   enabled: true
+  ## This applies to deployments which don't use helm's --namespace flag to set the namespace.
+  ## If Pulsar's namespace is manually set using the `namespace` key, this setting should match the same namespace,
+  ## otherwise Prometheus will not be able to scrape the Pulsar metrics due to RBAC restrictions.
+  ## See https://prometheus-operator.dev/kube-prometheus/kube/monitoring-other-namespaces/ if you need to install
+  ## kube-prometheus-stack in a different namespace than Pulsar.
+  # namespaceOverride: ""
   ## Manages Prometheus and Alertmanager components
   prometheusOperator:
     enabled: true


### PR DESCRIPTION
### Motivation

See #444, this takes the chart towards "secure-by-default". There are remaining gaps even after this change.

### Modifications

- change Pulsar Proxy's service type in values.yaml from LoadBalancer to ClusterIP
- add documentation 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
