### PR TITLE
Use bookkeeperMetadataServiceUri in broker and make PulsarMetadataClientDriver configurable

### DIFF
--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -37,11 +37,10 @@ data:
   {{- $configMetadataStoreUrl = printf "zk:%s%s" (include "pulsar.zookeeper.connect" .) .Values.metadataPrefix }}
   {{- end }}
   configurationMetadataStoreUrl: "{{ $configMetadataStoreUrl }}"
-  # setting bookkeeperMetadataServiceUri causes a NPE in WorkerUtils.initializeDlogNamespace which is a bug in Pulsar
-  # omit setting bookkeeperMetadataServiceUri until the bug is fixed when functions are enabled.
-  # bookkeeperMetadataServiceUri will default to configurationMetadataStoreUrl + "/ledgers" in that case
-  {{- if not .Values.components.functions }}
+  {{- if .Values.pulsar_metadata.bookkeeper.usePulsarMetadataClientDriver }}
   bookkeeperMetadataServiceUri: "metadata-store:{{ $configMetadataStoreUrl }}/ledgers"
+  {{- else }}
+  bookkeeperMetadataServiceUri: "zk+hierarchical://{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
   {{- end }}
   {{- end }}
   {{- if .Values.components.oxia }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -912,8 +912,15 @@ pulsar_metadata:
   ## Maximum size of a batch (in KB)
   metadataStoreBatchingMaxSizeKb: 128
 
-  ## BookKeeper metadata configuration settings with Pulsar Helm Chart deployments
+  ## BookKeeper client and BookKeeper metadata configuration settings with Pulsar Helm Chart deployments
   bookkeeper:
+    ## Controls whether to use the PIP-45 metadata driver (PulsarMetadataClientDriver) for BookKeeper client
+    ## in the Pulsar Broker when using ZooKeeper as a metadata store.
+    ## This is setting applies to Pulsar Broker's BookKeeper client.
+    ## When set to true, Pulsar Broker's BookKeeper client will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
+    ## When set to false, Pulsar Broker's BookKeeper client will use BookKeeper's default ZooKeeper connection implementation.
+    usePulsarMetadataClientDriver: false
+
     ## Controls whether to use the PIP-45 metadata driver (PulsarMetadataBookieDriver) for BookKeeper components
     ## when using ZooKeeper as a metadata store.
     ## This is a global setting that applies to all BookKeeper components.


### PR DESCRIPTION
For completeness of PIP-45 configuration it's useful to make it configurable whether PulsarMetadataClientDriver is used for BookKeeper client in the broker or not.