### PR TITLE
Upgrade Oxia to 0.11.15

### DIFF
--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - command:
             {{- include "oxia.coordinator.entrypoint" . | nindent 12 }}
           image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
-          imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
+          imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.oxia "root" .) }}"
           name: coordinator
           ports:
             {{- range $key, $value := .Values.oxia.coordinator.ports }}

--- a/charts/pulsar/templates/oxia-server-statefulset.yaml
+++ b/charts/pulsar/templates/oxia-server-statefulset.yaml
@@ -114,8 +114,8 @@ spec:
             {{- if .Values.oxia.pprofEnabled }}
             - "--profile"
             {{- end}}
-          image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
+          image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
+          imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.oxia "root" .) }}"
           name: server
           ports:
             {{- range $key, $value := .Values.oxia.server.ports }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -210,8 +210,8 @@ images:
     hasCommand: false
   oxia:
     repository: streamnative/oxia
-    tag: 0.11.9
-    pullPolicy: Always
+    tag: 0.11.15
+    pullPolicy:
 
 ## TLS
 ## templates/tls-certs.yaml


### PR DESCRIPTION
### Motivation

- Keep Oxia version up-to-date

### Modifications

- upgrade default Oxia version to 0.11.15
- use `defaultPullPolicy` for Oxia

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
