### PR TITLE
Add appAnnotations for all statefulsets

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -23,6 +23,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.autorecovery.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -23,6 +23,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.bookkeeper.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -25,6 +25,7 @@ metadata:
   name: {{ $stsName | quote }}
   {{- $namespace := include "pulsar.namespace" . }}
   namespace: {{ $namespace | quote }}
+  annotations: {{ .Values.broker.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -26,6 +26,7 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.oxia.component }}-coordinator
+  annotations: {{ .Values.oxia.coordinator.appAnnotations | toYaml | nindent 4 }}
 spec:
   replicas: 1
   selector:

--- a/charts/pulsar/templates/oxia-server-statefulset.yaml
+++ b/charts/pulsar/templates/oxia-server-statefulset.yaml
@@ -26,6 +26,7 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.oxia.component }}-server
+  annotations: {{ .Values.oxia.server.appAnnotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.oxia.server.replicas }}
   selector:

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -23,6 +23,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.proxy.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -23,6 +23,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.pulsar_manager.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -23,6 +23,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.toolset.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.toolset.component }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -24,6 +24,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   namespace: {{ template "pulsar.namespace" . }}
+  annotations: {{ .Values.zookeeper.appAnnotations | toYaml | nindent 4 }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -501,6 +501,8 @@ oxia:
   replicationFactor: 3
 ## templates/coordinator-deployment.yaml
   coordinator:
+    # annotations for the app (statefulset/deployment)
+    appAnnotations: {}
     # This is how Victoria Metrics or Prometheus discovers this component
     podMonitor:
       enabled: true
@@ -523,6 +525,8 @@ oxia:
       # cloud.google.com/gke-nodepool: default-pool
 ## templates/server-statefulset.yaml
   server:
+    # annotations for the app (statefulset/deployment)
+    appAnnotations: {}
     # This is how Victoria Metrics or Prometheus discovers this component
     podMonitor:
       enabled: true

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -385,6 +385,8 @@ zookeeper:
     type: requiredDuringSchedulingIgnoredDuringExecution
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -638,6 +640,8 @@ bookkeeper:
     type: requiredDuringSchedulingIgnoredDuringExecution
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -828,6 +832,8 @@ autorecovery:
     type: requiredDuringSchedulingIgnoredDuringExecution
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   # tolerations: []
   gracePeriod: 30
@@ -1025,6 +1031,8 @@ broker:
     type: preferredDuringSchedulingIgnoredDuringExecution
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1277,6 +1285,8 @@ proxy:
     type: requiredDuringSchedulingIgnoredDuringExecution
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1445,6 +1455,8 @@ toolset:
     # cloud.google.com/gke-nodepool: default-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1728,6 +1740,8 @@ pulsar_manager:
   # cloud.google.com/gke-nodepool: default-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # annotations for the app (statefulset/deployment)
+  appAnnotations: {}
   annotations: {}
   tolerations: []
   extraVolumes: []


### PR DESCRIPTION

### Motivation
Annotations are needed in apps (statefulsets/deployments) for operators in cluster (i.e reloader)

### Modifications
Add custom annotations for each component statefulset/deployment (app)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
