### PR TITLE
oxia components podmonitor match labels

### DIFF
--- a/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
@@ -19,5 +19,5 @@
 
 # deploy oxia-coordinator PodMonitor only when `$.Values.oxia.coordinator.podMonitor.enabled` is true
 {{- if and $.Values.components.oxia $.Values.oxia.coordinator.podMonitor.enabled }}
-{{- include "pulsar.podMonitor" (list . "oxia.coordinator" "app.kubernetes.io/component: oxia-coordinator" "metrics") }}
+{{- include "pulsar.podMonitor" (list . "oxia.server" (printf "component: %s-coordinator" .Values.oxia.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
@@ -19,5 +19,5 @@
 
 # deploy oxia-coordinator PodMonitor only when `$.Values.oxia.coordinator.podMonitor.enabled` is true
 {{- if and $.Values.components.oxia $.Values.oxia.coordinator.podMonitor.enabled }}
-{{- include "pulsar.podMonitor" (list . "oxia.coordinator" (printf "component: %s-coordinator" .Values.oxia.component)) }}
+{{- include "pulsar.podMonitor" (list . "oxia.coordinator" (printf "component: %s-coordinator" .Values.oxia.component) "metrics") }}
 {{- end }}

--- a/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-podmonitor.yaml
@@ -19,5 +19,5 @@
 
 # deploy oxia-coordinator PodMonitor only when `$.Values.oxia.coordinator.podMonitor.enabled` is true
 {{- if and $.Values.components.oxia $.Values.oxia.coordinator.podMonitor.enabled }}
-{{- include "pulsar.podMonitor" (list . "oxia.server" (printf "component: %s-coordinator" .Values.oxia.component)) }}
+{{- include "pulsar.podMonitor" (list . "oxia.coordinator" (printf "component: %s-coordinator" .Values.oxia.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/oxia-server-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-server-podmonitor.yaml
@@ -19,5 +19,5 @@
 
 # deploy oxia-server PodMonitor only when `$.Values.oxia.server.podMonitor.enabled` is true
 {{- if and $.Values.components.oxia $.Values.oxia.server.podMonitor.enabled }}
-{{- include "pulsar.podMonitor" (list . "oxia.server" "app.kubernetes.io/component: oxia-server" "metrics") }}
+{{- include "pulsar.podMonitor" (list . "oxia.server" (printf "component: %s-server" .Values.oxia.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/oxia-server-podmonitor.yaml
+++ b/charts/pulsar/templates/oxia-server-podmonitor.yaml
@@ -19,5 +19,5 @@
 
 # deploy oxia-server PodMonitor only when `$.Values.oxia.server.podMonitor.enabled` is true
 {{- if and $.Values.components.oxia $.Values.oxia.server.podMonitor.enabled }}
-{{- include "pulsar.podMonitor" (list . "oxia.server" (printf "component: %s-server" .Values.oxia.component)) }}
+{{- include "pulsar.podMonitor" (list . "oxia.server" (printf "component: %s-server" .Values.oxia.component) "metrics") }}
 {{- end }}


### PR DESCRIPTION
Fixes mismatch between podmonitor for oxia (coordinator and server) and labels for the pods.

### Motivation

This is a bug that prevents podmonitor to work properly - it can't match pods so metrics won't be ingested. For example, for oxia-server pods it's set to `component: oxia-server` but in podMonitor it's `kubernetes.io/component: oxia-server`.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.
