### PR TITLE
configurable oxia coordinator configmap and entrypoint

### DIFF
--- a/charts/pulsar/templates/_oxia.tpl
+++ b/charts/pulsar/templates/_oxia.tpl
@@ -106,7 +106,11 @@ Define coordinator entrypoint
 {{- define "oxia.coordinator.entrypoint" -}}
 - "oxia"
 - "coordinator"
+{{- if .Values.oxia.coordinator.customConfigMapName }}
+- "--conf=configmap:{{ template "pulsar.namespace" . }}/{{ .Values.oxia.coordinator.customConfigMapName }}"
+{{- else }}
 - "--conf=configmap:{{ template "pulsar.namespace" . }}/{{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-coordinator"
+{{- end }}
 - "--log-json"
 - "--metadata=configmap"
 - "--k8s-namespace={{ template "pulsar.namespace" . }}"

--- a/charts/pulsar/templates/oxia-coordinator-configmap.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-configmap.yaml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-{{- if .Values.components.oxia }}
+{{- if and .Values.components.oxia (not .Values.oxia.coordinator.customConfigMapName) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -45,18 +45,22 @@ spec:
         prometheus.io/port: "{{ .Values.oxia.coordinator.ports.metrics }}"
         {{- end }}
     spec:
-    {{- if .Values.oxia.server.nodeSelector }}
+    {{- if .Values.oxia.coordinator.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.oxia.server.nodeSelector | indent 8 }}
+{{ toYaml .Values.oxia.coordinator.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.oxia.server.tolerations }}
+    {{- if .Values.oxia.coordinator.tolerations }}
       tolerations:
-{{ toYaml .Values.oxia.server.tolerations | indent 8 }}
+{{ toYaml .Values.oxia.coordinator.tolerations | indent 8 }}
     {{- end }}    
       serviceAccountName: {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-coordinator
       containers:
         - command:
+{{- if .Values.oxia.coordinator.entrypoint }}
+{{ toYaml .Values.oxia.coordinator.entrypoint | indent 12 }}
+{{- else }}
             {{- include "oxia.coordinator.entrypoint" . | nindent 12 }}
+{{- end }}
           image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
           imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.oxia "root" .) }}"
           name: coordinator

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -520,7 +520,7 @@ oxia:
     # nodeSelector:
       # cloud.google.com/gke-nodepool: default-pool
     # customConfigMapName: ""
-    # entrypoint: {}
+    # entrypoint: []
 ## templates/server-statefulset.yaml
   server:
     # This is how Victoria Metrics or Prometheus discovers this component

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -118,7 +118,7 @@ components:
   # zookeeper
   zookeeper: true
   # oxia
-  oxia: true
+  oxia: false
   # bookkeeper
   bookkeeper: true
   # bookkeeper - autorecovery

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -118,7 +118,7 @@ components:
   # zookeeper
   zookeeper: true
   # oxia
-  oxia: false
+  oxia: true
   # bookkeeper
   bookkeeper: true
   # bookkeeper - autorecovery
@@ -519,6 +519,8 @@ oxia:
     tolerations: []
     # nodeSelector:
       # cloud.google.com/gke-nodepool: default-pool
+    # customConfigMapName: ""
+    # entrypoint: {}
 ## templates/server-statefulset.yaml
   server:
     # This is how Victoria Metrics or Prometheus discovers this component


### PR DESCRIPTION
It enables possibility to configure oxia coordinator and its configmap externally.

### Motivation

Coordinator's configmap contains list of of oxia servers. To enable autoscaling for servers, coordinator needs to be updated with newly added or removed server pods. It's impossible w/o configurable config map name as suggested in this PR.

Also, fixed a bug about coordinator.tolerations and coordinator.nodeSelector.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.
