### PR TITLE
update nodeSelector for bookkeeper cluster initializer

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
     {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-      {{- with .Values.pulsar_metadata.nodeSelector }}
+      {{- if .Values.pulsar_metadata.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}


### PR DESCRIPTION
Fixes a nullpointer execption inside of bookkeeper-cluster-initialize.yaml

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*
The problem was the nodeSelector for pulsar_metadata wasn't working as expected because the "with" [flow control](https://helm.sh/docs/chart_template_guide/control_structures/) was used instead of the "if" flow control. This resulted in a nullpointer exceptions. 

You can see various examples of "if" being used when setting the nodeSelector

-[ pulsar-manager-cluster-initialize.yaml](https://github.com/apache/pulsar-helm-chart/blob/77ec4cedfb002dfa91136ca0e808568e237018a6/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml#L38-L40)
-[ broker-statefulset.yaml](https://github.com/apache/pulsar-helm-chart/blob/77ec4cedfb002dfa91136ca0e808568e237018a6/charts/pulsar/templates/broker-statefulset.yaml#L79)
- [etc](https://github.com/search?q=repo%3Aapache%2Fpulsar-helm-chart%20nodeSelector&type=code)

### Modifications

*Describe the modifications you've done.*
I replaced the "with" with "if" [flow control](https://helm.sh/docs/chart_template_guide/control_structures/).


### Verifying this change

- [ ] Make sure that the change passes the CI checks.
