### PR TITLE
extra containers and volumes for oxia coordinator

### DIFF
--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -74,4 +74,11 @@ spec:
             {{- include "oxia-cluster.probe" .Values.oxia.coordinator.ports.internal | nindent 12 }}
           readinessProbe:
             {{- include "oxia-cluster.probe" .Values.oxia.coordinator.ports.internal | nindent 12 }}
+      {{- if .Values.oxia.coordinator.extraContainers }}
+        {{- toYaml .Values.oxia.coordinator.extraContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.oxia.coordinator.extraVolumes }}
+      volumes:
+{{- toYaml .Values.oxia.coordinator.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -523,6 +523,8 @@ oxia:
     tolerations: []
     # nodeSelector:
       # cloud.google.com/gke-nodepool: default-pool
+    extraContainers: []
+    extraVolumes: []
 ## templates/server-statefulset.yaml
   server:
     # annotations for the app (statefulset/deployment)


### PR DESCRIPTION
Adding extra containers 

### Motivation

We're working on autoscaling for oxia component where we'll create configmap that is going to be added into coordinator pod spec. So when new oxia servers are added it gets reflected in coordinator's config.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.
