### PR TITLE
Upgrade to Pulsar 4.0.5

### DIFF
--- a/.ci/clusters/values-pulsar-previous-lts.yaml
+++ b/.ci/clusters/values-pulsar-previous-lts.yaml
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-defaultPulsarImageTag: 3.0.11
+defaultPulsarImageTag: 3.0.12

--- a/charts/pulsar/Chart.yaml
+++ b/charts/pulsar/Chart.yaml
@@ -18,7 +18,7 @@
 #
 
 apiVersion: v2
-appVersion: "4.0.4"
+appVersion: "4.0.5"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
 version: 4.0.1


### PR DESCRIPTION
- upgrades to Pulsar 4.0.5 by setting `appVersion`
- use `3.0.12` for previous LTS in CI tests