### PR TITLE
extra volume mounts for oxia coordinator

### DIFF
--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -77,6 +77,10 @@ spec:
             limits:
               cpu: {{ .Values.oxia.coordinator.cpuLimit }}
               memory: {{ .Values.oxia.coordinator.memoryLimit }}
+      {{- if .Values.pulsar.oxia.coordinator.extraVolumeMounts }}
+          volumeMounts:
+        {{- toYaml .Values.pulsar.oxia.coordinator.extraVolumeMounts | nindent 12 }}
+      {{- end }}
           livenessProbe:
             {{- include "oxia-cluster.probe" .Values.oxia.coordinator.ports.internal | nindent 12 }}
           readinessProbe:


### PR DESCRIPTION
This change allows to add extra volume mounts for oxia coordinator container. In our case we need to share a volume between oxia coordinator container and another container that creates config file for it dynamically.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
