### PR TITLE
extra volume mounts for autorecovery [init] containers

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -123,6 +123,9 @@ spec:
         - |
           bin/certs-combine-pem.sh /pulsar/certs/cacerts/ca-combined.pem {{ template "pulsar.certs.cacerts" (dict "certs" .Values.tls.autorecovery.cacerts.certs) }}
         volumeMounts:
+        {{- if .Values.autorecovery.initContainersExtraVolumeMounts }}
+{{ toYaml .Values.autorecovery.initContainersExtraVolumeMounts | indent 8 }}
+        {{- end }}
         {{- include "pulsar.autorecovery.certs.volumeMounts" . | nindent 8 }}
       {{- end }}
       {{- if and .Values.autorecovery.waitBookkeeperTimeout (gt (.Values.autorecovery.waitBookkeeperTimeout | int) 0) }}
@@ -140,8 +143,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
         volumeMounts:
-        {{- if .Values.autorecovery.extraVolumeMounts }}
-{{ toYaml .Values.autorecovery.extraVolumeMounts | indent 8 }}
+        {{- if .Values.autorecovery.initContainersExtraVolumeMounts }}
+{{ toYaml .Values.autorecovery.initContainersExtraVolumeMounts | indent 8 }}
         {{- end }}
         {{- include "pulsar.autorecovery.certs.volumeMounts" . | nindent 8 }}
       {{- end }}
@@ -174,6 +177,9 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
         volumeMounts:
+        {{- if .Values.autorecovery.extraVolumeMounts }}
+{{ toYaml .Values.autorecovery.extraVolumeMounts | indent 8 }}
+        {{- end }}
         {{- include "pulsar.autorecovery.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- include "pulsar.autorecovery.certs.volumes" . | nindent 6 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -949,6 +949,7 @@ autorecovery:
       -Xms64m -Xmx64m
     PULSAR_PREFIX_useV2WireProtocol: "true"
   extraVolumes: []
+  initContainersExtraVolumeMounts: []
   extraVolumeMounts: []
 
 ## Pulsar Zookeeper metadata. The metadata will be deployed as


### PR DESCRIPTION
### Motivation

This PR adds possibility to define extra volume mounts for init and regular containers of autorecovery pod.  This is an addition to https://github.com/apache/pulsar-helm-chart/pull/607 -- now it's possible to have a separation between volume mounts for `initContainers:` and `containers:`.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
