### PR TITLE
Correct Zookeeper URL to k8s

### DIFF
--- a/charts/pulsar/templates/_zookeeper.tpl
+++ b/charts/pulsar/templates/_zookeeper.tpl
@@ -33,10 +33,10 @@ Define the pulsar zookeeper
 {{- $zk -}}
 {{ else }}
 {{- if not (and .Values.tls.enabled .Values.tls.zookeeper.enabled) -}}
-{{ template "pulsar.zookeeper.service" . }}:{{ .Values.zookeeper.ports.client }}
+{{ template "pulsar.zookeeper.service" . }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.zookeeper.ports.client }}
 {{- end -}}
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled -}}
-{{ template "pulsar.zookeeper.service" . }}:{{ .Values.zookeeper.ports.clientTls }}
+{{ template "pulsar.zookeeper.service" . }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.zookeeper.ports.clientTls }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -195,11 +195,11 @@ spec:
               sleep 3;
             done;
             echo "bookkeeper cluster is already initialized";
-            bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }} | grep Name | wc -l)";
+            bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} | grep Name | wc -l)";
             until [ ${bookieServiceNumber} -ge {{ .Values.broker.configData.managedLedgerDefaultEnsembleSize }} ]; do
-              echo "bookkeeper cluster {{ template "pulsar.cluster.name" . }} isn't ready yet ... check in 10 seconds ...";
+              echo "bookkeeper cluster {{ template "pulsar.cluster.name" . }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} isn't ready yet ... check in 10 seconds ...";
               sleep 10;
-              bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }} | grep Name | wc -l)";
+              bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} | grep Name | wc -l)";
             done;
             echo "bookkeeper cluster is ready";
         envFrom:

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -197,7 +197,7 @@ spec:
             echo "bookkeeper cluster is already initialized";
             bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} | grep Name | wc -l)";
             until [ ${bookieServiceNumber} -ge {{ .Values.broker.configData.managedLedgerDefaultEnsembleSize }} ]; do
-              echo "bookkeeper cluster {{ template "pulsar.cluster.name" . }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} isn't ready yet ... check in 10 seconds ...";
+              echo "bookkeeper cluster {{ template "pulsar.cluster.name" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} isn't ready yet ... check in 10 seconds ...";
               sleep 10;
               bookieServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.{{ .Values.clusterDomain }} | grep Name | wc -l)";
             done;

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1166,7 +1166,7 @@ broker:
       -XX:+ExitOnOutOfMemoryError
       -XX:+DisableExplicitGC
       -XX:+PerfDisableSharedMem
-    managedLedgerDefaultEnsembleSize: "2"
+    managedLedgerDefaultEnsembleSize: "1"
     managedLedgerDefaultWriteQuorum: "2"
     managedLedgerDefaultAckQuorum: "2"
 


### PR DESCRIPTION
Fixes # 
 
Fixing URL for connecting to Zookeeper for k8s services

### Motivation

  Motivated by the helm chart installation outside the default namespace. Broker connection failure with zookeeper pulsar-tributaliza-zookeeper:2181, should be pulsar-tributaliza-zookeeper.namespace.svc.cluster.local:2181

### Modifications

 Changed the definition of define "pulsar.zookeeper.connect" to include the full service URL

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
