### PR TITLE
Correct VM Operator CRDs version

### DIFF
--- a/scripts/victoria-metrics-k8s-stack/upgrade_vm_operator_crds.sh
+++ b/scripts/victoria-metrics-k8s-stack/upgrade_vm_operator_crds.sh
@@ -19,5 +19,5 @@
 #
 
 # This script is used to upgrade the Victoria Metrics Operator CRDs before running "helm upgrade"
-VM_OPERATOR_VERSION="${1:-"0.42.4"}"
+VM_OPERATOR_VERSION="${1:-"0.53.0"}"
 kubectl apply --server-side --force-conflicts -f "https://github.com/VictoriaMetrics/operator/releases/download/v${VM_OPERATOR_VERSION}/crd.yaml"


### PR DESCRIPTION
Fixes Wrong VM Operator CRDs version

### Motivation
I tried to use pulsar-helm-chart 4.2.0 but it was failed to start vm-operator due to some CRDs missed. Finally I figured out the version in [upgrade_vm_operator_crds.sh](https://github.com/apache/pulsar-helm-chart/blob/master/scripts/victoria-metrics-k8s-stack/upgrade_vm_operator_crds.sh) is wrong.

victoria-metrics-k8s-stack 0.38.x uses vm-operator v0.53.0. 
Details: [vm-operator-0.42.x-chart.yml](https://github.com/VictoriaMetrics/helm-charts/blob/victoria-metrics-operator-0.42.5/charts/victoria-metrics-operator/Chart.yaml)
<img width="685" height="526" alt="image" src="https://github.com/user-attachments/assets/4d31aa4a-155c-4bea-91cc-b5a43a1ea1b9" />

### Modifications
upgrade Operator version from 0.42.4 to 0.53.0 in upgrade_vm_operator_crds.sh

### Verifying this change

- [x] Make sure that the change passes the CI checks.
