### PR TITLE
Remove statsProviderClass config for bookkeeper

### DIFF
--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -150,8 +150,6 @@ zkTimeout: "{{ .Values.pulsar_metadata.bookkeeper.metadataStoreSessionTimeoutMil
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-# config the stats provider
-statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 # use hostname as the bookie id
 useHostNameAsBookieID: "true"
 {{- end }}


### PR DESCRIPTION
- prepare for 4.2.0 support since `statsProviderClass` has changed in Pulsar 4.2.0
- the default value for `statsProviderClass` is present in `conf/bookkeeper.conf` and there's no need to override it.