### PR TITLE
fix: fix extra volumes indentation for rendering the helm chart properly

### DIFF
--- a/charts/pulsar/templates/dekaf-deployment.yaml
+++ b/charts/pulsar/templates/dekaf-deployment.yaml
@@ -108,6 +108,6 @@ spec:
       {{- end }}
 
       {{- if ((.Values.dekaf).deployment).extraVolumes }}
-        {{- toYaml .Values.dekaf.deployment.extraVolumes | default list | nindent 8 }}
+        {{- toYaml .Values.dekaf.deployment.extraVolumes | default list | nindent 6 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #651

### Motivation

The goal is to fix a indentation issue causing the dekaf deployment helm template not to render properly when setting extra volumes, this is useful when you mount a jwt token for authenticating with dekaf

### Modifications

Set the identation from 8 to 6

### Verifying this change
Go to `pulsar-helm-chart/charts/pulsar`

Create test-values.yaml:
```
components:
  dekaf: true

dekaf:
  persistence:
    storageClass: "gp3"
  deployment:
    extraEnv:
    - name: DEKAF_PUBLIC_BASE_URL
      value: "http://dekaf-int-dev.test.com"
    extraVolumeMounts:
      - name: admin-token
        mountPath: /pulsar/tokens/admin
        readOnly: true
    extraVolumes:
      - name: admin-token
        secret:
          secretName: pulsar-token-admin
```

Running `helm template pulsar . -f test-values.yaml --show-only templates/dekaf-deployment.yaml` renders properly