### PR TITLE
fix: Add chart control for `updateStrategy` to brokers and proxies

### DIFF
--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -38,8 +38,7 @@ spec:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: {{ .Values.broker.component }}
-  updateStrategy:
-    type: RollingUpdate
+  updateStrategy: {{ .Values.broker.updateStrategy | toYaml | nindent 4 }}
   {{- /*
   When functions are enabled, podManagementPolicy must be OrderedReady to ensure that other started brokers are available via DNS
   for the function worker to connect to.

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -36,8 +36,7 @@ spec:
     matchLabels:
       {{- include "pulsar.matchLabels" . | nindent 6 }}
       component: {{ .Values.proxy.component }}
-  updateStrategy:
-    type: RollingUpdate
+  updateStrategy: {{ .Values.proxy.updateStrategy | toYaml | nindent 4 }}
   podManagementPolicy: Parallel
   template:
     metadata:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1109,6 +1109,8 @@ broker:
     behavior: ~
   # The podManagementPolicy cannot be modified for an existing deployment. If you need to change this value, you will need to manually delete the existing broker StatefulSet and then redeploy the chart.
   podManagementPolicy:
+  updateStrategy:
+    type: RollingUpdate
   initContainers: []
   # This is how Victoria Metrics or Prometheus discovers this component
   podMonitor:
@@ -1370,6 +1372,8 @@ proxy:
     maxReplicas: 3
     metrics: ~
     behavior: ~
+  updateStrategy:
+    type: RollingUpdate
   initContainers: []
   # This is how Victoria Metrics or Prometheus discovers this component
   podMonitor:


### PR DESCRIPTION
Fixes: #667

### Motivation

A user can control the `updateStrategy` for the pods of bookies and zookeeper. However, the values for brokers and proxies is hardcoded. Being able to control this value via the Helm chart is crucial to being able to do smooth chart upgrades to a fully-running cluster. For example, setting the strategy to `OnDelete` would allow a user to control which order the pods are restarted after an upgrade.

### Modifications

For Broker and Proxy templates, set a default, but allow overrides from `.Values.xxx.updateStrategy`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
