### PR TITLE
Enable TLS certificate file refresh for BookKeeper components by default

### DIFF
--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -165,7 +165,7 @@ PULSAR_PREFIX_tlsKeyStoreType: PEM
 PULSAR_PREFIX_tlsKeyStore: /pulsar/certs/bookie/tls.key
 PULSAR_PREFIX_tlsTrustStoreType: PEM
 PULSAR_PREFIX_tlsTrustStore: {{ ternary "/pulsar/certs/cacerts/ca-combined.pem" "/pulsar/certs/ca/ca.crt" .Values.tls.bookie.cacerts.enabled | quote }}
-PULSAR_PREFIX_tlsCertFilesRefreshDurationSeconds: 300
+PULSAR_PREFIX_tlsCertFilesRefreshDurationSeconds: "300"
 {{- end }}
 {{- end }}
 

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -165,6 +165,7 @@ PULSAR_PREFIX_tlsKeyStoreType: PEM
 PULSAR_PREFIX_tlsKeyStore: /pulsar/certs/bookie/tls.key
 PULSAR_PREFIX_tlsTrustStoreType: PEM
 PULSAR_PREFIX_tlsTrustStore: {{ ternary "/pulsar/certs/cacerts/ca-combined.pem" "/pulsar/certs/ca/ca.crt" .Values.tls.bookie.cacerts.enabled | quote }}
+PULSAR_PREFIX_tlsCertFilesRefreshDurationSeconds: 300
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
See https://github.com/apache/pulsar/issues/25369 / https://github.com/apache/pulsar/pull/25370