### PR TITLE
Update standalone defaults to use zookeeper

### DIFF
--- a/charts/pulsar/templates/standalone-configmap.yaml
+++ b/charts/pulsar/templates/standalone-configmap.yaml
@@ -29,6 +29,11 @@ metadata:
 data:
   clusterName: {{ template "pulsar.cluster.name" . }}
 
+  # Use embedded ZooKeeper as the metadata store. Set to "0" in values.yaml to use RocksDB instead.
+  # ZooKeeper is preferred here because it is more battle-tested as a Pulsar metadata store
+  # and leaves the door open for migrating the data to a real cluster later.
+  PULSAR_STANDALONE_USE_ZOOKEEPER: "1"
+
   # Standalone-specific defaults: single-node replication
   managedLedgerDefaultEnsembleSize: "1"
   managedLedgerDefaultWriteQuorum: "1"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1225,6 +1225,7 @@ standalone:
       # storageClassName:
       selector: {}
   configData:
+    PULSAR_STANDALONE_USE_ZOOKEEPER: "1"
     PULSAR_MEM: >
       -Xms256m -Xmx512m -XX:MaxDirectMemorySize=512m
     PULSAR_GC: >

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1225,7 +1225,6 @@ standalone:
       # storageClassName:
       selector: {}
   configData:
-    PULSAR_STANDALONE_USE_ZOOKEEPER: "1"
     PULSAR_MEM: >
       -Xms256m -Xmx512m -XX:MaxDirectMemorySize=512m
     PULSAR_GC: >


### PR DESCRIPTION
### Motivation

Addresses comment from [previous PR](https://github.com/apache/pulsar-helm-chart/pull/674#issuecomment-4313610009)

### Modifications

Per the comment, default `PULSAR_STANDALONE_USE_ZOOKEEPER=1` when using standalone mode.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
