### PR TITLE
Fix oxia coordinator RoleBinding roleRef.apiGroup to prevent GitOps drift

### DIFF
--- a/charts/pulsar/templates/oxia-coordinator-rolebinding.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-rolebinding.yaml
@@ -31,7 +31,7 @@ subjects:
     name: {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-coordinator
     namespace: {{ template "pulsar.namespace" . }}
 roleRef:
-  apiGroup: ""
+  apiGroup: "rbac.authorization.k8s.io"
   kind: Role
   name: {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-coordinator
 {{- end }}


### PR DESCRIPTION
Fixes #666

The empty `apiGroup: ""` was silently filled in by the Kubernetes API server with `rbac.authorization.k8s.io`. GitOps tools like Pulumi and ArgoCD detected the mismatch on every reconcile and tried to recreate the RoleBinding. Because `roleRef` is immutable, this caused the binding to be deleted and recreated on every deployment.
