### PR TITLE
Set FQDN to cluster domain instead of hard coded cluster.local

### DIFF
--- a/charts/pulsar/templates/_oxia.tpl
+++ b/charts/pulsar/templates/_oxia.tpl
@@ -90,7 +90,8 @@ namespaces:
 servers:
   {{- $servicename := printf "%s-%s-svc" (include "pulsar.fullname" .) .Values.oxia.component }}
   {{- $publicservicename := printf "%s-%s" (include "pulsar.fullname" .) .Values.oxia.component }}
-  {{- $fqdnSuffix := printf "%s.svc.cluster.local" (include "pulsar.namespace" .) }}
+  {{- $fqdnSuffix := printf "%s.svc.%s" (include "pulsar.namespace" .) .Values.clusterDomain }}
+
   {{- $podnamePrefix := printf "%s-%s-server-" (include "pulsar.fullname" .) .Values.oxia.component }}
   {{- $publicPort := $.Values.oxia.server.ports.public }}
   {{- range until (int .Values.oxia.server.replicas) }}
@@ -133,4 +134,3 @@ Define coordinator entrypoint
 - "--profile"
 {{- end}}
 {{- end}}
-


### PR DESCRIPTION
Fixes #679

### Motivation
The cluster is not guaranteed to use cluster.local as its domain.

### Modifications
Remove the hard coded cluster.local value and use the same variable as everywhere else.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
