### PR TITLE
Fix nodeSelector and tolerations handling in dekaf-deployment.yaml

### DIFF
--- a/charts/pulsar/templates/dekaf-deployment.yaml
+++ b/charts/pulsar/templates/dekaf-deployment.yaml
@@ -45,12 +45,12 @@ spec:
     spec:
       {{- if ((.Values.dekaf).deployment).nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 10 }}
+        {{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 6 }}
       {{- end }}
 
       {{- if ((.Values.dekaf).deployment).tolerations }}
       tolerations:
-        {{ toYaml .Values.dekaf.deployment.tolerations | default list | indent 8 }}
+        {{ toYaml .Values.dekaf.deployment.tolerations | default list | indent 4 }}
       {{- end }}
 
       containers:

--- a/charts/pulsar/templates/dekaf-deployment.yaml
+++ b/charts/pulsar/templates/dekaf-deployment.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       {{- if ((.Values.dekaf).deployment).nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 10 }}
+{{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 8 }}
       {{- end }}
 
       {{- if ((.Values.dekaf).deployment).tolerations }}

--- a/charts/pulsar/templates/dekaf-deployment.yaml
+++ b/charts/pulsar/templates/dekaf-deployment.yaml
@@ -45,12 +45,12 @@ spec:
     spec:
       {{- if ((.Values.dekaf).deployment).nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 6 }}
+{{ toYaml .Values.dekaf.deployment.nodeSelector | default dict | indent 10 }}
       {{- end }}
 
       {{- if ((.Values.dekaf).deployment).tolerations }}
       tolerations:
-        {{ toYaml .Values.dekaf.deployment.tolerations | default list | indent 4 }}
+{{ toYaml .Values.dekaf.deployment.tolerations | default list | indent 8 }}
       {{- end }}
 
       containers:


### PR DESCRIPTION
Fix for the Dekaf UI issue reported in here: https://github.com/apache/pulsar-helm-chart/issues/681

Fixes: https://github.com/apache/pulsar-helm-chart/issues/681

### Motivation

Rendering of the `dekaf-deployment.yaml` template fails when `Values.dekaf.deployment.nodeSelector` and `Values.dekaf.deployment.tolerations` are true.

```
Error: INSTALLATION FAILED: YAML parse error on pulsar/templates/dekaf-deployment.yaml: error converting YAML to JSON: yaml: line 55: did not find expected key
helm.go:92: 2026-05-04 11:04:33.581691 +0200 CEST m=+1.425366083 [debug] error converting YAML to JSON: yaml: line 55: did not find expected key
YAML parse error on pulsar/templates/dekaf-deployment.yaml
```

### Modifications

This PR adjusts the indentations configured in lines 48 and 53

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
