### PR TITLE
Fix nodeSelector and tolerations handling in pulsar-manager-cluster-initialize.yaml

### DIFF
--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -44,11 +44,11 @@ spec:
     {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
       nodeSelector:
       {{- if .Values.pulsar_metadata.nodeSelector }}
-      {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
+      {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 4 }}
       {{- end }}
       tolerations:
       {{- if .Values.pulsar_metadata.tolerations }}
-      {{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
+      {{ toYaml .Values.pulsar_metadata.tolerations | indent 4 }}
       {{- end }}
       restartPolicy: OnFailure
       initContainers:

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -44,11 +44,11 @@ spec:
     {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
       nodeSelector:
       {{- if .Values.pulsar_metadata.nodeSelector }}
-      {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 4 }}
+{{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.pulsar_metadata.tolerations }}
-      {{ toYaml .Values.pulsar_metadata.tolerations | indent 4 }}
+{{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       initContainers:


### PR DESCRIPTION
Fix for the Pulsar Manager issue reported in here: https://github.com/apache/pulsar-helm-chart/issues/681

Fixes: https://github.com/apache/pulsar-helm-chart/issues/681

### Motivation

Rendering of the `pulsar-manager-cluster-initialize.yaml` template fails when `Values.pulsar_metadata.nodeSelector` and `Values.pulsar_metadata.tolerations` are true.

```
Error: INSTALLATION FAILED: YAML parse error on pulsar/templates/dekaf-deployment.yaml: error converting YAML to JSON: yaml: line 55: did not find expected key
helm.go:92: 2026-05-04 11:04:33.581691 +0200 CEST m=+1.425366083 [debug] error converting YAML to JSON: yaml: line 55: did not find expected key
YAML parse error on pulsar/templates/dekaf-deployment.yaml
```

### Modifications

This PR adjusts the indentations configured in lines 43 and 47.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
