### PR TITLE
Fix fully-qualified dns name

### DIFF
--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -341,14 +341,14 @@ function ci::test_pulsar_producer_consumer() {
     echo "Testing with ${action}"
     if [[ "$(ci::helm_values_for_deployment | yq .standalone.enabled)" == "true" ]]; then
       if [[ "$(ci::helm_values_for_deployment | yq .tls.enabled)" == "true" ]]; then
-        PROXY_URL="pulsar+ssl://pulsar-ci-standalone:6651"
+        PROXY_URL="pulsar+ssl://pulsar-ci-standalone.${NAMESPACE}.svc.cluster.local:6651"
       else
-        PROXY_URL="pulsar://pulsar-ci-standalone:6650"
+        PROXY_URL="pulsar://pulsar-ci-standalone.${NAMESPACE}.svc.cluster.local:6650"
       fi
     elif [[ "$(ci::helm_values_for_deployment | yq .tls.proxy.enabled)" == "true" ]]; then
-      PROXY_URL="pulsar+ssl://pulsar-ci-proxy:6651"
+      PROXY_URL="pulsar+ssl://pulsar-ci-proxy.${NAMESPACE}.svc.cluster.local:6651"
     else
-      PROXY_URL="pulsar://pulsar-ci-proxy:6650"
+      PROXY_URL="pulsar://pulsar-ci-proxy.${NAMESPACE}.svc.cluster.local:6650"
     fi
     set -x
     if [[ "${action}" == "produce" || "${action}" == "produce-consume" ]]; then

--- a/charts/pulsar/templates/_certs.tpl
+++ b/charts/pulsar/templates/_certs.tpl
@@ -107,9 +107,9 @@ spec:
 {{ toYaml .tlsConfig.dnsNames | indent 4 }}
 {{- end }}
     {{- if or (eq .componentConfig.component "broker") (eq .componentConfig.component "zookeeper") }}
-    - {{ printf "*.%s-%s-headless.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
+    - {{ printf "%s-%s-headless.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
     {{- end }}
-    - {{ printf "*.%s-%s.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
+    - {{ printf "%s-%s.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
     - {{ printf "%s-%s" (include "pulsar.fullname" .root) .componentConfig.component | quote }}
 {{- if .tlsConfig.ipAddresses }}
   ipAddresses:

--- a/charts/pulsar/templates/_certs.tpl
+++ b/charts/pulsar/templates/_certs.tpl
@@ -107,7 +107,10 @@ spec:
 {{ toYaml .tlsConfig.dnsNames | indent 4 }}
 {{- end }}
     {{- if or (eq .componentConfig.component "broker") (eq .componentConfig.component "zookeeper") }}
+    - {{ printf "*.%s-%s-headless.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
     - {{ printf "%s-%s-headless.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
+    {{- else }}
+    - {{ printf "*.%s-%s.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
     {{- end }}
     - {{ printf "%s-%s.%s.svc.%s" (include "pulsar.fullname" .root) .componentConfig.component (include "pulsar.namespace" .root) .root.Values.clusterDomain | quote }}
     - {{ printf "%s-%s" (include "pulsar.fullname" .root) .componentConfig.component | quote }}


### PR DESCRIPTION
### Motivation

The generated `dnsNames` on certificates were incorrect for fully-qualified service names. The template emitted `*.<release>-<component>.<namespace>.svc.<clusterDomain>` for every component, but a wildcard subdomain only makes sense for headless services that resolve individual pod hostnames (`pod-name.<headless-service>....`). For non-headless services (e.g. `proxy`, `standalone`) the cert should match the plain `<release>-<component>.<namespace>.svc.<clusterDomain>` name, and clients connecting via the fully-qualified service name would otherwise fail hostname verification.

### Modifications

- `charts/pulsar/templates/_certs.tpl`: emit headless SANs (with wildcard) for components backed by a headless `StatefulSet` (`broker`, `zookeeper`, plus `bookkeeper` via the existing headless block), and emit the wildcard regular-service SAN only for non-headless components. The plain `<release>-<component>.<namespace>.svc.<clusterDomain>` SAN is always included so clients can connect via the fully-qualified service name.
- `.ci/helm.sh`: update the producer/consumer smoke tests to use the fully-qualified DNS names (`pulsar-ci-standalone.<namespace>.svc.cluster.local`, `pulsar-ci-proxy.<namespace>.svc.cluster.local`) so TLS hostname verification exercises the corrected cert SANs.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.