### PR TITLE
Add support for extra init command to Broker STS upgrade for Istio sidecar support

### DIFF
--- a/charts/pulsar/templates/broker-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/broker-statefulset-upgrade.yaml
@@ -112,4 +112,7 @@ spec:
               else
                 echo "Chart version $CHART_LABEL is 4.6.0 or newer, skipping delete"
               fi
+            {{- if .Values.extraInitCommand }}
+              {{ .Values.extraInitCommand }}
+            {{- end }}
 {{- end }}


### PR DESCRIPTION
### Motivation

The STS upgrade job does not terminate when using Istio as the sidecar container is not aware that the job is complete.

### Modifications

Similar to the solution in the other `initialize` jobs I have added the same functionality in the STS upgrade job

```
grep extraInit *
bookkeeper-cluster-initialize.yaml:            {{- if .Values.extraInitCommand }}
bookkeeper-cluster-initialize.yaml:              {{ .Values.extraInitCommand }}
pulsar-cluster-initialize.yaml:            {{- if .Values.extraInitCommand }}
pulsar-cluster-initialize.yaml:              {{ .Values.extraInitCommand }}
pulsar-cluster-initialize.yaml:            {{- if .Values.extraInitCommand }}
pulsar-cluster-initialize.yaml:              {{ .Values.extraInitCommand }}
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
