### PR TITLE
Upgrade to Oxia 0.16.7

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -222,7 +222,7 @@ images:
     pullPolicy:
   oxia:
     repository: oxia/oxia
-    tag: 0.16.6
+    tag: 0.16.7
     pullPolicy:
   standalone:
     # uses defaultPulsarImageRepository when unspecified


### PR DESCRIPTION
Release notes: https://github.com/oxia-db/oxia/releases/tag/v0.16.7