### PR TITLE
Add oxia.server.walSyncData to optionally disable WAL fsync for testing

### DIFF
--- a/charts/pulsar/templates/oxia-server-statefulset.yaml
+++ b/charts/pulsar/templates/oxia-server-statefulset.yaml
@@ -118,6 +118,9 @@ spec:
             - "--data-dir=/data/db"
             - "--wal-dir=/data/wal"
             - "--db-cache-size-mb={{ .Values.oxia.server.dbCacheSizeMb }}"
+            {{- if and (hasKey .Values.oxia.server "walSyncData") (eq (.Values.oxia.server.walSyncData | toString) "false") }}
+            - "--wal-sync-data=false"
+            {{- end }}
             {{- if .Values.oxia.pprofEnabled }}
             - "--profile"
             {{- end}}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -719,6 +719,12 @@ oxia:
     memoryLimit: 1Gi
     # Oxia database cache size in MB
     dbCacheSizeMb: 512
+    # Whether the Oxia server fsyncs write-ahead-log data to disk after each write.
+    # Defaults to "true" for durability. Set to "false" to disable WAL fsync for faster
+    # writes in testing scenarios (risks data loss on crash/power loss; not for production).
+    # When (and only when) this key is present and set to false, the chart passes
+    # "--wal-sync-data=false" to the oxia server; otherwise oxia keeps syncing (the default).
+    walSyncData: "true"
     # Storage size for the PVC of the server pod
     storageSize: 8Gi
     # Storage class name for the PVC of the server pod

--- a/examples/README.md
+++ b/examples/README.md
@@ -148,7 +148,7 @@ in examples that deploy a broker.
 | [`values-bookkeeper-aws.yaml`](values-bookkeeper-aws.yaml) | A 3-bookie cluster using AWS EBS (`gp2`) `PersistentVolumeClaims` for the BookKeeper journal and ledgers. Monitoring stack disabled. |
 | [`values-zookeeper-aws.yaml`](values-zookeeper-aws.yaml) | A configuration store running only ZooKeeper backed by AWS EBS (`gp2`) volumes, including the `externalZookeeperServerList` option for building a ZooKeeper cluster that spans namespaces/clusters. |
 | [`values-faster-disk-cleanup.yaml`](values-faster-disk-cleanup.yaml) | Tune BookKeeper and the broker to reclaim disk space as fast as possible: frequent BookKeeper entry-log compaction and garbage collection, lower disk-utilization GC thresholds, a smaller rollover-heavy journal with no backups, and faster broker managed-ledger rollover so closed ledgers are trimmed sooner. For space-constrained test clusters; the values are not tuned for production. |
-| [`values-disable-fsync.yaml`](values-disable-fsync.yaml) | Disable fsync on the BookKeeper journal (`journalSyncData: false`) and ZooKeeper (`forceSync: false`) for faster writes in tests. Trades durability for speed — data written just before a crash or power loss can be lost — so it is **not for production**. |
+| [`values-disable-fsync.yaml`](values-disable-fsync.yaml) | Disable fsync on the BookKeeper journal (`journalSyncData: false`), ZooKeeper (`forceSync: false`) and the Oxia WAL (`walSyncData: false`, when Oxia is the metadata store) for faster writes in tests. Trades durability for speed — data written just before a crash or power loss can be lost — so it is **not for production**. |
 
 ### Security (TLS and authentication)
 

--- a/examples/values-disable-fsync.yaml
+++ b/examples/values-disable-fsync.yaml
@@ -26,3 +26,9 @@ zookeeper:
   configData:
     # disable fsync for testing purposes (not recommended for production)
     forceSync: "false"
+
+oxia:
+  server:
+    # disable WAL fsync for testing purposes (not recommended for production)
+    # applies when Oxia is used as the metadata store (components.oxia: true)
+    walSyncData: "false"


### PR DESCRIPTION
Add an `oxia.server.walSyncData` value (default "true"). When the key is present and set to false, the oxia server StatefulSet passes `--wal-sync-data=false` so WAL data is not fsynced to disk after each write.

The flag is only emitted when the key exists and is explicitly false (string or boolean), so sync data cannot be turned off accidentally by an unset or default value. The flag name matches the oxia 0.16.7 CLI (`--wal-sync-data`, a pflag boolean, hence the `=false` form).

Also enable it in examples/values-disable-fsync.yaml and document it there and in examples/README.md alongside the BookKeeper and ZooKeeper fsync toggles.