### PR TITLE
Add CI scenario: Pulsar v5 with Oxia and Pulsar Functions

### DIFF
--- a/.ci/clusters/values-pulsar-v5-functions.yaml
+++ b/.ci/clusters/values-pulsar-v5-functions.yaml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Test Pulsar v5 together with Oxia and Pulsar Functions.
+#
+# This combines the examples/values-oxia.yaml and examples/values-functions-fs-storage.yaml scenarios on the
+# Pulsar 5.0.0-M1 image: it runs Functions on an Oxia-backed cluster (no ZooKeeper). Functions require the
+# broker-hosted Packages Management Service; its default BookKeeper package storage needs ZooKeeper, so
+# FileSystemPackagesStorage is enabled instead (no ZooKeeper dependency). The function smoke test
+# (ci::test_pulsar_function) creates a function from a JAR, which uploads the package via the broker's
+# FileSystem-backed Packages Management Service.
+
+# Use the slim apachepulsar/pulsar image (not the default apachepulsar/pulsar-all) at the v5 milestone tag.
+defaultPulsarImageRepository: apachepulsar/pulsar
+defaultPulsarImageTag: 5.0.0-M1
+
+# From examples/values-oxia.yaml and examples/values-functions-fs-storage.yaml.
+components:
+  zookeeper: false
+  oxia: true
+  functions: true
+
+# Host the Packages Management Service on the broker with FileSystemPackagesStorage so functions work on
+# Oxia. broker.replicaCount is 1 in CI (.ci/values-common.yaml), so the default ReadWriteOnce PVC on the
+# kind default StorageClass is sufficient (no shared filesystem needed).
+broker:
+  packageManagement:
+    enabled: true
+    fileSystemStorage:
+      enabled: true
+      # Use a NON-default storage path so the test actually exercises PULSAR_PREFIX_STORAGE_PATH being
+      # applied to the broker. The FileSystemPackagesStorage default ("packages-storage") would resolve to
+      # /pulsar/packages-storage (the cwd), which happens to match the chart's default mount path, so a
+      # broken STORAGE_PATH wiring would still pass. With a custom path the PVC is mounted here AND
+      # STORAGE_PATH points here, so the function-package upload only lands on the volume if both are wired
+      # correctly. ci::verify_package_storage_files asserts the uploaded package files exist under this path.
+      storagePath: /pulsar/test-packages-storage
+
+# Size Oxia down for the resource-constrained kind cluster used in CI.
+oxia:
+  initialShardCount: 3
+  replicationFactor: 3
+  server:
+    replicas: 3
+    cpuLimit: 333m
+    memoryLimit: 200Mi
+    dbCacheSizeMb: 100
+    storageSize: 1Gi

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -287,6 +287,9 @@ jobs:
           - name: Oxia + FileSystemPackagesStorage
             values_file: .ci/clusters/values-oxia.yaml
             shortname: oxia
+          - name: Pulsar v5 with Oxia and Pulsar Functions
+            values_file: .ci/clusters/values-pulsar-v5-functions.yaml
+            shortname: pulsar-v5-functions
           - name: OpenID
             values_file: .ci/clusters/values-openid.yaml
             shortname: openid


### PR DESCRIPTION
## Motivation

Add CI coverage for **Pulsar v5** running together with **Oxia** (no ZooKeeper) and **Pulsar Functions**.

This validates the `apachepulsar/pulsar:5.0.0-M1` image in the metadata-store-on-Oxia + broker-hosted Functions configuration, ensuring the upcoming Pulsar 5.0 release works end to end with the chart's Oxia and FileSystemPackagesStorage support.

## Modifications

- Add `.ci/clusters/values-pulsar-v5-functions.yaml`:
  - `defaultPulsarImageRepository: apachepulsar/pulsar` + `defaultPulsarImageTag: 5.0.0-M1` (slim image at the v5 milestone tag).
  - Combines the `examples/values-oxia.yaml` (ZooKeeper off, Oxia on) and `examples/values-functions-fs-storage.yaml` (Functions on with broker-hosted FileSystemPackagesStorage) scenarios.
  - Oxia server sized down for the resource-constrained kind cluster used in CI, mirroring `.ci/clusters/values-oxia.yaml`.
- Add the matrix entry **"Pulsar v5 with Oxia and Pulsar Functions"** (`shortname: pulsar-v5-functions`) to the `install-chart-tests` job in `.github/workflows/pulsar-helm-chart-ci.yaml`.

The existing function smoke test (`ci::test_pulsar_function`) runs automatically because `components.functions: true`; it creates a function from the bundled `api-examples.jar`, uploading the package via the broker's FileSystem-backed Packages Management Service, and `ci::verify_package_storage_files` asserts the package landed on the volume.

## Verification

- `helm template` + `kubeconform -strict` pass for k8s 1.25.0 and 1.34.0 (43/43 resources valid); render uses `apachepulsar/pulsar:5.0.0-M1`, no ZooKeeper resources, `metadataStoreUrl: oxia://...`, and `PULSAR_PREFIX_STORAGE_PATH: /pulsar/test-packages-storage`.
- Confirmed the `apachepulsar/pulsar:5.0.0-M1` image tag is published on Docker Hub.
- Full install test runs in CI via the new matrix scenario.
