### PR TITLE
fix: omit empty broker clusterIP to avoid GitOps drift

### DIFF
--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -46,7 +46,7 @@ spec:
   - name: "{{ .Values.tlsPrefix }}pulsarssl"
     port: {{ .Values.broker.ports.pulsarssl }}
   {{- end }}
-  {{- if ne .Values.broker.service.clusterIP "" }}
+  {{- if .Values.broker.service.clusterIP }}
   clusterIP: "{{ .Values.broker.service.clusterIP }}"
   {{- end }}
   selector:

--- a/charts/pulsar/templates/broker-service.yaml
+++ b/charts/pulsar/templates/broker-service.yaml
@@ -46,7 +46,9 @@ spec:
   - name: "{{ .Values.tlsPrefix }}pulsarssl"
     port: {{ .Values.broker.ports.pulsarssl }}
   {{- end }}
+  {{- if ne .Values.broker.service.clusterIP "" }}
   clusterIP: "{{ .Values.broker.service.clusterIP }}"
+  {{- end }}
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}


### PR DESCRIPTION
Omit clusterIP from the broker Service manifest when the value is empty, matching standalone-service.yaml. Prevents perpetual Argo CD OutOfSync when Kubernetes assigns a ClusterIP after apply.

Fixes apache/pulsar-helm-chart#700