### PR TITLE
fix: always use policy/v1 for PodDisruptionBudget templates

### DIFF
--- a/charts/pulsar/templates/bookkeeper-pdb.yaml
+++ b/charts/pulsar/templates/bookkeeper-pdb.yaml
@@ -19,12 +19,7 @@
 
 {{- if and .Values.components.bookkeeper (not .Values.standalone.enabled) }}
 {{- if .Values.bookkeeper.pdb.usePolicy }}
-# pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/charts/pulsar/templates/broker-pdb.yaml
+++ b/charts/pulsar/templates/broker-pdb.yaml
@@ -19,12 +19,7 @@
 
 {{- if and .Values.components.broker (not .Values.standalone.enabled) }}
 {{- if .Values.broker.pdb.usePolicy }}
-# pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/function-worker-pdb.yaml
+++ b/charts/pulsar/templates/function-worker-pdb.yaml
@@ -19,12 +19,7 @@
 
 {{- if and .Values.components.function_worker (not .Values.standalone.enabled) }}
 {{- if .Values.function_worker.pdb.usePolicy }}
-# pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function_worker.component }}"

--- a/charts/pulsar/templates/proxy-pdb.yaml
+++ b/charts/pulsar/templates/proxy-pdb.yaml
@@ -19,12 +19,7 @@
 
 {{- if .Values.components.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
-# pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/charts/pulsar/templates/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper-pdb.yaml
@@ -20,12 +20,7 @@
 # deploy zookeeper only when `components.zookeeper` is true
 {{- if and .Values.components.zookeeper (not .Values.standalone.enabled) }}
 {{- if .Values.zookeeper.pdb.usePolicy }}
-# pdb version detection
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"


### PR DESCRIPTION
Remove semverCompare branching for policy/v1beta1. The chart requires Kubernetes >= 1.25 where policy/v1beta1 PDB was removed.

Fixes apache/pulsar-helm-chart#701