### PR TITLE
Use pulsar.zookeeper.connect template in bookkeeper cluster initialize command.

### DIFF
--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -114,7 +114,7 @@ spec:
                 echo "bookkeeper cluster already initialized";
             else
                 {{- if and .Values.components.zookeeper (not (eq .Values.metadataPrefix "")) }}
-                bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} create {{ .Values.metadataPrefix }} && echo 'created for pulsar cluster "{{ template "pulsar.cluster.name" . }}"' &&
+                bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} create {{ .Values.metadataPrefix }} && echo 'created for pulsar cluster "{{ template "pulsar.cluster.name" . }}"' &&
                 {{- end }}
                 bin/bookkeeper shell initnewcluster;
             fi


### PR DESCRIPTION
Used pulsar.fullname appended with zookeeper name before which does not account for TLS port numbers.

Fixes #706

