### PR TITLE
Keep the internal CA private key across renewals with cert-manager 1.18+

### DIFF
--- a/charts/pulsar/templates/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls-cert-internal-issuer.yaml
@@ -45,6 +45,10 @@ spec:
     - server auth
     - client auth
   isCA: true
+{{- if .Values.certs.internal_issuer.privateKey }}
+  privateKey:
+    {{- toYaml .Values.certs.internal_issuer.privateKey | nindent 4 }}
+{{- end }}
   issuerRef:
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}"
     # We can reference ClusterIssuers by changing the kind here.

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -495,6 +495,13 @@ certs:
     duration: 2160h
     # 15d
     renewBefore: 360h
+    # Private key settings for the self-signed CA certificate.
+    # Keep rotationPolicy at Never so the CA key survives renewals. Since
+    # cert-manager 1.18 the default is Always, which generates a new CA key
+    # on every renewal and invalidates all certificates issued by the old key
+    # until each of them has been re-issued.
+    privateKey:
+      rotationPolicy: Never
   issuers:
     # Used for certs.internal_issuer.type as selfsigning
     selfsigning:


### PR DESCRIPTION
Fixes #708

### Motivation

Since cert-manager 1.18 the default `privateKey.rotationPolicy` is `Always` (GA in 1.20, can no longer be turned off). The chart's self-signed CA Certificate doesn't set the field, so the CA now gets a new private key on every renewal and all previously issued certificates stop validating until each of them has been re-issued. See #708.

### Modifications

- add `certs.internal_issuer.privateKey` to `values.yaml`, defaulting to `rotationPolicy: Never`
- render it as the `privateKey` block of the internal CA Certificate

`rotationPolicy: Never` keeps the CA key across renewals, which was the behavior before cert-manager 1.18. Setting `certs.internal_issuer.privateKey: null` renders the same manifest as before this change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
