### PR TITLE
Add nodeAffinity support to all scheduled workloads

### DIFF
--- a/.ci/templates-all-values-patch1.yaml
+++ b/.ci/templates-all-values-patch1.yaml
@@ -89,6 +89,26 @@ volumes:
 #     the storageClassName: "local-storage" branch
 # -----------------------------------------------------------------------------
 zookeeper:
+  affinity:
+    # nodeAffinity: replace the base file's single-entry preferred list with a
+    # two-entry weighted one. Helm deep-merges maps, so the base file's
+    # requiredDuringScheduling... term survives alongside it.
+    nodeAffinity: &nodeAffinity
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-pool
+                operator: In
+                values:
+                  - pool-a
+        - weight: 10
+          preference:
+            matchExpressions:
+              - key: node-pool
+                operator: In
+                values:
+                  - fallback-pool
   statefulsetUpgrade:
     enabled: false
   volumes:
@@ -111,6 +131,8 @@ zookeeper:
 #            bookkeeper-storageclass.yaml common-volume branch.
 # -----------------------------------------------------------------------------
 bookkeeper:
+  affinity:
+    nodeAffinity: *nodeAffinity
   volumes:
     useSingleCommonVolume: true
     journal:
@@ -145,6 +167,8 @@ bookkeeper:
 #     enablePackagesManagement keys in broker-configmap.yaml).
 # -----------------------------------------------------------------------------
 broker:
+  affinity:
+    nodeAffinity: *nodeAffinity
   statefulsetUpgrade:
     enabled: false
   packageManagement:
@@ -221,3 +245,12 @@ auth:
       openIDRequireIssuersUseHttps: "true"
   superUsers:
     manager: ""
+
+# -----------------------------------------------------------------------------
+# Function worker nodeAffinity -- the separate function-worker StatefulSet only
+# renders under this overlay (components.function_worker), so the base file has
+# no function_worker block to carry it.
+# -----------------------------------------------------------------------------
+function_worker:
+  affinity:
+    nodeAffinity: *nodeAffinity

--- a/.ci/templates-all-values.yaml
+++ b/.ci/templates-all-values.yaml
@@ -213,6 +213,18 @@ auth:
         affinity:
           anti_affinity: true
           type: requiredDuringSchedulingIgnoredDuringExecution
+          # Single required term -- the anchored multi-term value used by the
+          # component blocks is defined later in the file, so this one is
+          # spelled out in full.
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: node-pool
+                      operator: In
+                      values:
+                        - pool-a
+                        - pool-b
       # Two annotation keys on the signing-key secret -- exercises the
       # `range $k, $v := ...secretAnnotations.key` loop in jwt-secret-init.yaml
       secretAnnotations:
@@ -271,6 +283,37 @@ extraDeploy:
 #            / annotations indent.
 # -----------------------------------------------------------------------------
 zookeeper:
+  affinity:
+    # Two nodeSelectorTerms (OR), several matchExpressions per term (AND),
+    # matchFields, and required + preferred together -- exercises the
+    # `toYaml | nindent` passthrough with a deeply nested multi-element value.
+    nodeAffinity: &nodeAffinity
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-pool
+                operator: In
+                values:
+                  - pool-a
+                  - pool-b
+              - key: dedicated
+                operator: Exists
+          - matchExpressions:
+              - key: gpu-count
+                operator: Gt
+                values:
+                  - "2"
+            matchFields:
+              - key: metadata.name
+                operator: In
+                values:
+                  - node-1
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: spot
+                operator: DoesNotExist
   replicaCount: 3
   podMonitor:
     enabled: true
@@ -345,6 +388,8 @@ zookeeper:
 #            bookkeeper-configmap.yaml multi-volume directory list rendering.
 # -----------------------------------------------------------------------------
 bookkeeper:
+  affinity:
+    nodeAffinity: *nodeAffinity
   replicaCount: 4
   podMonitor:
     enabled: true
@@ -451,6 +496,8 @@ bookkeeper:
 # Autorecovery -- multi-element lists/maps + custom timeout
 # -----------------------------------------------------------------------------
 autorecovery:
+  affinity:
+    nodeAffinity: *nodeAffinity
   podMonitor:
     enabled: true
     interval: 30s
@@ -509,6 +556,8 @@ autorecovery:
 # pulsar_metadata -- exercise PIP-45 metadata driver toggles + extra init cmd
 # -----------------------------------------------------------------------------
 pulsar_metadata:
+  affinity:
+    nodeAffinity: *nodeAffinity
   bookkeeper:
     usePulsarMetadataClientDriver: true
     usePulsarMetadataBookieDriver: true
@@ -518,6 +567,8 @@ extraInitCommand: "echo 'extra init command'"
 # Standalone -- left disabled (mutually exclusive with the distributed setup)
 # -----------------------------------------------------------------------------
 standalone:
+  affinity:
+    nodeAffinity: *nodeAffinity
   enabled: false
 
 # -----------------------------------------------------------------------------
@@ -528,6 +579,8 @@ standalone:
 #            block.
 # -----------------------------------------------------------------------------
 broker:
+  affinity:
+    nodeAffinity: *nodeAffinity
   replicaCount: 3
   autoscaling:
     enabled: true
@@ -634,6 +687,8 @@ functions:
 #            and is covered indirectly by other scenarios).
 # -----------------------------------------------------------------------------
 proxy:
+  affinity:
+    nodeAffinity: *nodeAffinity
   replicaCount: 3
   podMonitor:
     enabled: true
@@ -722,6 +777,8 @@ proxy:
 # Toolset -- multi-element lists/maps
 # -----------------------------------------------------------------------------
 toolset:
+  affinity:
+    nodeAffinity: *nodeAffinity
   useProxy: true
   priorityClassName: high-priority-nonpreempting
   appAnnotations:
@@ -771,6 +828,8 @@ oxia:
   initialShardCount: 3
   replicationFactor: 3
   coordinator:
+    affinity:
+      nodeAffinity: *nodeAffinity
     priorityClassName: high-priority-nonpreempting
     appAnnotations:
       deploy/owner: pulsar-team
@@ -816,6 +875,8 @@ oxia:
       - oxia-internal.example.com:6648
       - oxia-external.example.com:6648
   server:
+    affinity:
+      nodeAffinity: *nodeAffinity
     priorityClassName: high-priority-nonpreempting
     appAnnotations:
       deploy/owner: pulsar-team
@@ -853,6 +914,8 @@ oxia:
 #            pulsar-manager-cluster-initialize.yaml.
 # -----------------------------------------------------------------------------
 pulsar_manager:
+  affinity:
+    nodeAffinity: *nodeAffinity
   priorityClassName: high-priority-nonpreempting
   appAnnotations:
     deploy/owner: pulsar-team
@@ -919,6 +982,8 @@ pulsar_manager:
 # -----------------------------------------------------------------------------
 dekaf:
   deployment:
+    affinity:
+      nodeAffinity: *nodeAffinity
     priorityClassName: high-priority-nonpreempting
     annotations:
       deploy/owner: pulsar-team

--- a/README.md
+++ b/README.md
@@ -217,6 +217,24 @@ We provide some instructions to guide you through the preparation: http://pulsar
       anti_affinity: false
     ```
 
+   To pin a component to specific nodes (for example a dedicated GKE node pool), set that component's
+   `affinity.nodeAffinity`. It is passed through to the pod spec verbatim, so any native
+   [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+   expression works, and it composes with the chart's own pod anti-affinity rather than replacing them:
+
+    ```yaml
+    broker:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: cloud.google.com/gke-nodepool
+                    operator: In
+                    values:
+                      - pulsar-pool
+    ```
+
 2. Install the chart:
 
     ```bash

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -73,6 +73,18 @@ spec:
         {{- toYaml .Values.autorecovery.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.autorecovery.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.autorecovery.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.autorecovery.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.autorecovery.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.autorecovery.affinity.anti_affinity}}
         podAntiAffinity:
           {{ if eq .Values.autorecovery.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -73,17 +73,9 @@ spec:
         {{- toYaml .Values.autorecovery.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.autorecovery.affinity.node_affinity}}
+        {{- with .Values.autorecovery.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.autorecovery.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.autorecovery.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.autorecovery.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.autorecovery.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -52,6 +52,11 @@ spec:
       {{- if .Values.pulsar_metadata.tolerations }}
 {{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
       {{- end }}
+      {{- with (.Values.pulsar_metadata.affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       initContainers:
       {{- if .Values.tls.bookie.cacerts.enabled }}
       - name: cacerts

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -70,6 +70,18 @@ spec:
         {{- toYaml .Values.bookkeeper.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.bookkeeper.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.bookkeeper.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.bookkeeper.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.bookkeeper.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity}}
         podAntiAffinity:
           {{- if eq .Values.bookkeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -70,17 +70,9 @@ spec:
         {{- toYaml .Values.bookkeeper.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.bookkeeper.affinity.node_affinity}}
+        {{- with .Values.bookkeeper.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.bookkeeper.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.bookkeeper.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.bookkeeper.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/broker-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/broker-statefulset-upgrade.yaml
@@ -90,6 +90,19 @@ spec:
     spec:
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-sts-cleanup"
       restartPolicy: Never
+      {{- if .Values.broker.affinity.node_affinity }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.broker.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.broker.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.broker.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+      {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"

--- a/charts/pulsar/templates/broker-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/broker-statefulset-upgrade.yaml
@@ -90,8 +90,24 @@ spec:
     spec:
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-sts-cleanup"
       restartPolicy: Never
-      {{- if .Values.broker.affinity.node_affinity }}
+      {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
+    {{- if .Values.broker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.broker.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.broker.priorityClassName }}
+      priorityClassName: {{ .Values.broker.priorityClassName }}
+    {{- end }}
+    {{- if .Values.broker.tolerations }}
+      tolerations:
+{{ toYaml .Values.broker.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.broker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.broker.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
+        {{- if .Values.broker.affinity.node_affinity}}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -102,10 +118,51 @@ spec:
                 {{- range .Values.broker.affinity.node_affinity.matchExpression.values }}
                 - {{ . }}
                 {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
+        podAntiAffinity:
+          {{- if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
+          {{ .Values.broker.affinity.type }}:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.broker.component }}
+            topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
+          {{- else }}
+          {{ .Values.broker.affinity.type }}:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.broker.component }}
+                topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"
+          imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.kubectl "root" .) }}"
           command:
             - sh
             - -c

--- a/charts/pulsar/templates/broker-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/broker-statefulset-upgrade.yaml
@@ -106,59 +106,15 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.broker.topologySpreadConstraints | nindent 8 }}
     {{- end }}
+    {{- /* This short-lived cleanup hook intentionally has no pod anti-affinity: spreading a
+         single-shot kubectl pod across nodes buys nothing, and inheriting the component's
+         required anti-affinity would make the hook unschedulable once every node already
+         runs a broker pod. */}}
+    {{- with .Values.broker.affinity.nodeAffinity }}
       affinity:
-        {{- if .Values.broker.affinity.node_affinity}}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.broker.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.broker.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.broker.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
-        {{- end }}
-        {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
-        podAntiAffinity:
-          {{- if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.broker.affinity.type }}:
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "pulsar.name" . }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.broker.component }}
-            topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
-          {{- else }}
-          {{ .Values.broker.affinity.type }}:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "app"
-                      operator: In
-                      values:
-                      - "{{ template "pulsar.name" . }}"
-                    - key: "release"
-                      operator: In
-                      values:
-                      - {{ .Release.Name }}
-                    - key: "component"
-                      operator: In
-                      values:
-                      - {{ .Values.broker.component }}
-                topologyKey: {{ .Values.broker.affinity.anti_affinity_topology_key }}
-          {{- end }}
-        {{- end }}
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -95,6 +95,18 @@ spec:
         {{- toYaml .Values.broker.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.broker.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.broker.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.broker.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.broker.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
         podAntiAffinity:
           {{- if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -95,17 +95,9 @@ spec:
         {{- toYaml .Values.broker.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.broker.affinity.node_affinity}}
+        {{- with .Values.broker.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.broker.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.broker.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.broker.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/dekaf-deployment.yaml
+++ b/charts/pulsar/templates/dekaf-deployment.yaml
@@ -57,6 +57,12 @@ spec:
       priorityClassName: {{ .Values.dekaf.deployment.priorityClassName }}
       {{- end }}
 
+      {{- with (((.Values.dekaf).deployment).affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+
       containers:
         - name: dekaf
           image: "{{ .Values.images.dekaf.repository }}:{{ .Values.images.dekaf.tag }}"

--- a/charts/pulsar/templates/function-worker-statefulset.yaml
+++ b/charts/pulsar/templates/function-worker-statefulset.yaml
@@ -71,6 +71,18 @@ spec:
         {{- toYaml .Values.function_worker.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.function_worker.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.function_worker.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.function_worker.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.function_worker.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.function_worker.affinity.anti_affinity }}
         podAntiAffinity:
           {{- if eq .Values.function_worker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}

--- a/charts/pulsar/templates/function-worker-statefulset.yaml
+++ b/charts/pulsar/templates/function-worker-statefulset.yaml
@@ -71,17 +71,9 @@ spec:
         {{- toYaml .Values.function_worker.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.function_worker.affinity.node_affinity}}
+        {{- with .Values.function_worker.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.function_worker.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.function_worker.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.function_worker.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.function_worker.affinity.anti_affinity }}
         podAntiAffinity:

--- a/charts/pulsar/templates/jwt-secret-init.yaml
+++ b/charts/pulsar/templates/jwt-secret-init.yaml
@@ -106,8 +106,21 @@ spec:
       tolerations:
 {{ toYaml .Values.auth.authentication.jwt.generateSecrets.tolerations | indent 8 }}
     {{- end }}
-      {{- if and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity }}
+      {{- if or .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity (and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity) }}
       affinity:
+        {{- if .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
+        {{- if and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity }}
         podAntiAffinity:
           {{- if eq .Values.auth.authentication.jwt.generateSecrets.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
           {{ .Values.auth.authentication.jwt.generateSecrets.affinity.type }}:
@@ -146,6 +159,7 @@ spec:
                       - jwt-secret-init
                 topologyKey: {{ .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity_topology_key }}
           {{- end }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: jwt-secrets

--- a/charts/pulsar/templates/jwt-secret-init.yaml
+++ b/charts/pulsar/templates/jwt-secret-init.yaml
@@ -106,19 +106,11 @@ spec:
       tolerations:
 {{ toYaml .Values.auth.authentication.jwt.generateSecrets.tolerations | indent 8 }}
     {{- end }}
-      {{- if or .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity (and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity) }}
+      {{- if or .Values.auth.authentication.jwt.generateSecrets.affinity.nodeAffinity (and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity) }}
       affinity:
-        {{- if .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity }}
+        {{- with .Values.auth.authentication.jwt.generateSecrets.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.auth.authentication.jwt.generateSecrets.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.auth.authentication.jwt.generateSecrets.affinity.anti_affinity }}
         podAntiAffinity:

--- a/charts/pulsar/templates/oxia-coordinator-deployment.yaml
+++ b/charts/pulsar/templates/oxia-coordinator-deployment.yaml
@@ -60,6 +60,11 @@ spec:
     {{- if .Values.oxia.coordinator.priorityClassName }}
       priorityClassName: {{ .Values.oxia.coordinator.priorityClassName }}
     {{- end }}
+    {{- with (.Values.oxia.coordinator.affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
       serviceAccountName: {{ template "pulsar.fullname" . }}-{{ .Values.oxia.component }}-coordinator
       containers:
         - command:

--- a/charts/pulsar/templates/oxia-server-statefulset.yaml
+++ b/charts/pulsar/templates/oxia-server-statefulset.yaml
@@ -65,6 +65,18 @@ spec:
       priorityClassName: {{ .Values.oxia.server.priorityClassName }}
     {{- end }}
       affinity:
+        {{- if .Values.oxia.server.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.oxia.server.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.oxia.server.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.oxia.server.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.oxia.server.affinity.anti_affinity}}
         podAntiAffinity:
           {{ if eq .Values.oxia.server.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/oxia-server-statefulset.yaml
+++ b/charts/pulsar/templates/oxia-server-statefulset.yaml
@@ -65,17 +65,9 @@ spec:
       priorityClassName: {{ .Values.oxia.server.priorityClassName }}
     {{- end }}
       affinity:
-        {{- if .Values.oxia.server.affinity.node_affinity}}
+        {{- with .Values.oxia.server.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.oxia.server.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.oxia.server.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.oxia.server.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.oxia.server.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -71,6 +71,18 @@ spec:
         {{- toYaml .Values.proxy.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.proxy.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.proxy.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.proxy.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.proxy.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity}}
         podAntiAffinity:
         {{ if eq .Values.proxy.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -71,17 +71,9 @@ spec:
         {{- toYaml .Values.proxy.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.proxy.affinity.node_affinity}}
+        {{- with .Values.proxy.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.proxy.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.proxy.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.proxy.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -48,6 +48,11 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pulsar_metadata.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with (.Values.pulsar_metadata.affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
       initContainers:
       {{- if .Values.tls.toolset.cacerts.enabled }}
       - name: cacerts

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -50,6 +50,11 @@ spec:
       {{- if .Values.pulsar_metadata.tolerations }}
 {{ toYaml .Values.pulsar_metadata.tolerations | indent 8 }}
       {{- end }}
+      {{- with (.Values.pulsar_metadata.affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       restartPolicy: OnFailure
       initContainers:
         - name: wait-pulsar-manager-ready

--- a/charts/pulsar/templates/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager-statefulset.yaml
@@ -62,6 +62,11 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.pulsar_manager.topologySpreadConstraints | nindent 8 }}
     {{- end }}
+    {{- with (.Values.pulsar_manager.affinity).nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.pulsar_manager.gracePeriod }}
       {{- if .Values.pulsar_manager.initContainers }}
       initContainers:

--- a/charts/pulsar/templates/standalone-deployment.yaml
+++ b/charts/pulsar/templates/standalone-deployment.yaml
@@ -101,6 +101,19 @@ spec:
       tolerations:
 {{ toYaml .Values.standalone.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.standalone.affinity.node_affinity }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.standalone.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.standalone.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.standalone.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.standalone.gracePeriod }}
       {{- if .Values.standalone.initContainers }}
       initContainers:

--- a/charts/pulsar/templates/standalone-deployment.yaml
+++ b/charts/pulsar/templates/standalone-deployment.yaml
@@ -101,18 +101,10 @@ spec:
       tolerations:
 {{ toYaml .Values.standalone.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.standalone.affinity.node_affinity }}
+    {{- with .Values.standalone.affinity.nodeAffinity }}
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.standalone.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.standalone.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.standalone.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.standalone.gracePeriod }}
       {{- if .Values.standalone.initContainers }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -65,6 +65,19 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.toolset.topologySpreadConstraints | nindent 8 }}
     {{- end }}
+    {{- if and .Values.toolset.affinity .Values.toolset.affinity.node_affinity }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.toolset.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.toolset.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.toolset.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
       initContainers:

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -65,18 +65,10 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.toolset.topologySpreadConstraints | nindent 8 }}
     {{- end }}
-    {{- if and .Values.toolset.affinity .Values.toolset.affinity.node_affinity }}
+    {{- with (.Values.toolset.affinity).nodeAffinity }}
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.toolset.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.toolset.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.toolset.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.toolset.gracePeriod }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"

--- a/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
@@ -90,6 +90,19 @@ spec:
     spec:
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-sts-cleanup"
       restartPolicy: Never
+      {{- if .Values.zookeeper.affinity.node_affinity }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.zookeeper.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+      {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"

--- a/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
@@ -90,8 +90,24 @@ spec:
     spec:
       serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-sts-cleanup"
       restartPolicy: Never
-      {{- if .Values.zookeeper.affinity.node_affinity }}
+      {{- include "pulsar.imagePullSecrets" . | nindent 6 }}
+    {{- if .Values.zookeeper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.zookeeper.priorityClassName }}
+      priorityClassName: {{ .Values.zookeeper.priorityClassName }}
+    {{- end }}
+    {{- if .Values.zookeeper.tolerations }}
+      tolerations:
+{{ toYaml .Values.zookeeper.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.zookeeper.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.zookeeper.topologySpreadConstraints | nindent 8 }}
+    {{- end }}
       affinity:
+        {{- if .Values.zookeeper.affinity.node_affinity}}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -102,10 +118,51 @@ spec:
                 {{- range .Values.zookeeper.affinity.node_affinity.matchExpression.values }}
                 - {{ . }}
                 {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
+        podAntiAffinity:
+          {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
+          {{ .Values.zookeeper.affinity.type }}:
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.zookeeper.component }}
+            topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
+        {{ else }}
+          {{ .Values.zookeeper.affinity.type }}:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.zookeeper.component }}
+                topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
+        {{ end }}
+        {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"
+          imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.kubectl "root" .) }}"
           command:
             - sh
             - -c

--- a/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset-upgrade.yaml
@@ -106,59 +106,15 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.zookeeper.topologySpreadConstraints | nindent 8 }}
     {{- end }}
+    {{- /* This short-lived cleanup hook intentionally has no pod anti-affinity: spreading a
+         single-shot kubectl pod across nodes buys nothing, and inheriting the component's
+         required anti-affinity would make the hook unschedulable once every node already
+         runs a zookeeper pod. */}}
+    {{- with .Values.zookeeper.affinity.nodeAffinity }}
       affinity:
-        {{- if .Values.zookeeper.affinity.node_affinity}}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.zookeeper.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
-        {{- end }}
-        {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
-        podAntiAffinity:
-          {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
-          {{ .Values.zookeeper.affinity.type }}:
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "pulsar.name" . }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.zookeeper.component }}
-            topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
-        {{ else }}
-          {{ .Values.zookeeper.affinity.type }}:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "app"
-                      operator: In
-                      values:
-                      - "{{ template "pulsar.name" . }}"
-                    - key: "release"
-                      operator: In
-                      values:
-                      - {{ .Release.Name }}
-                    - key: "component"
-                      operator: In
-                      values:
-                      - {{ .Values.zookeeper.component }}
-                topologyKey: {{ .Values.zookeeper.affinity.anti_affinity_topology_key }}
-        {{ end }}
-        {{- end }}
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
       containers:
         - name: sts-cleanup
           image: "{{ template "pulsar.imageFullName" (dict "image" .Values.images.kubectl "root" .) }}"

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -71,6 +71,18 @@ spec:
         {{- toYaml .Values.zookeeper.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
+        {{- if .Values.zookeeper.affinity.node_affinity}}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.key }}
+                operator: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.operator }}
+                values:
+                {{- range .Values.zookeeper.affinity.node_affinity.matchExpression.values }}
+                - {{ . }}
+                {{- end }}
+        {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
         podAntiAffinity:
           {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -71,17 +71,9 @@ spec:
         {{- toYaml .Values.zookeeper.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       affinity:
-        {{- if .Values.zookeeper.affinity.node_affinity}}
+        {{- with .Values.zookeeper.affinity.nodeAffinity }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.key }}
-                operator: {{ .Values.zookeeper.affinity.node_affinity.matchExpression.operator }}
-                values:
-                {{- range .Values.zookeeper.affinity.node_affinity.matchExpression.values }}
-                - {{ . }}
-                {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
         podAntiAffinity:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -430,6 +430,13 @@ auth:
           # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard)
           # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guarantee
           type: preferredDuringSchedulingIgnoredDuringExecution
+          # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+          # node_affinity:
+          #   matchExpression:
+          #     key: <node-label-key>
+          #     operator: In
+          #     values:
+          #       - <label-value>
       # Annotations to apply to secrets created by the generateSecrets job
       secretAnnotations:
         # Annotations added to the signing key secret (asymmetric-key or symmetric-key)
@@ -585,6 +592,13 @@ zookeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -872,6 +886,13 @@ bookkeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1086,6 +1107,13 @@ autorecovery:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1268,6 +1296,13 @@ standalone:
     anti_affinity: false
     anti_affinity_topology_key: kubernetes.io/hostname
     type: preferredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   appAnnotations: {}
   annotations: {}
   tolerations: []
@@ -1379,6 +1414,13 @@ broker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: preferredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1811,6 +1853,13 @@ proxy:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -809,6 +809,13 @@ oxia:
       # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
       # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
       type: requiredDuringSchedulingIgnoredDuringExecution
+      # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+      # node_affinity:
+      #   matchExpression:
+      #     key: <node-label-key>
+      #     operator: In
+      #     values:
+      #       - <label-value>
     # set topologySpreadConstraint to deploy pods across different zones
     topologySpreadConstraints: []
     tolerations: []
@@ -1740,6 +1747,13 @@ function_worker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard)
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guarantee
     type: preferredDuringSchedulingIgnoredDuringExecution
+    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+    # node_affinity:
+    #   matchExpression:
+    #     key: <node-label-key>
+    #     operator: In
+    #     values:
+    #       - <label-value>
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # priorityClassName: high-priority-nonpreempting

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -2040,6 +2040,15 @@ toolset:
   # priorityClassName: high-priority-nonpreempting
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
+  # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
+  # This component runs a single replica, so pod anti-affinity is not applicable; only node_affinity is supported.
+  # affinity:
+  #   node_affinity:
+  #     matchExpression:
+  #       key: <node-label-key>
+  #       operator: In
+  #       values:
+  #         - <label-value>
   # annotations for the app (statefulset/deployment)
   appAnnotations: {}
   annotations: {}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -430,13 +430,17 @@ auth:
           # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard)
           # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guarantee
           type: preferredDuringSchedulingIgnoredDuringExecution
-          # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-          # node_affinity:
-          #   matchExpression:
-          #     key: <node-label-key>
-          #     operator: In
-          #     values:
-          #       - <label-value>
+          # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+          # Unset by default, so no node affinity is applied. See
+          # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+          nodeAffinity: {}
+          #   requiredDuringSchedulingIgnoredDuringExecution:
+          #     nodeSelectorTerms:
+          #       - matchExpressions:
+          #           - key: node-pool
+          #             operator: In
+          #             values:
+          #               - pulsar-pool
       # Annotations to apply to secrets created by the generateSecrets job
       secretAnnotations:
         # Annotations added to the signing key secret (asymmetric-key or symmetric-key)
@@ -592,13 +596,17 @@ zookeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -747,6 +755,18 @@ oxia:
     # nodeSelector:
       # cloud.google.com/gke-nodepool: default-pool
     # priorityClassName: high-priority-nonpreempting
+    affinity:
+      # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+      # Unset by default, so no node affinity is applied. See
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+      nodeAffinity: {}
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: node-pool
+      #             operator: In
+      #             values:
+      #               - pulsar-pool
     extraContainers: []
     extraVolumes: []
     extraVolumeMounts: []
@@ -809,13 +829,17 @@ oxia:
       # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
       # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
       type: requiredDuringSchedulingIgnoredDuringExecution
-      # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-      # node_affinity:
-      #   matchExpression:
-      #     key: <node-label-key>
-      #     operator: In
-      #     values:
-      #       - <label-value>
+      # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+      # Unset by default, so no node affinity is applied. See
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+      nodeAffinity: {}
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: node-pool
+      #             operator: In
+      #             values:
+      #               - pulsar-pool
     # set topologySpreadConstraint to deploy pods across different zones
     topologySpreadConstraints: []
     tolerations: []
@@ -893,13 +917,17 @@ bookkeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1114,13 +1142,17 @@ autorecovery:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1245,6 +1277,18 @@ pulsar_metadata:
   #     effect: "NoSchedule"
   # nodeSelector: {}
   #   cloud.google.com/gke-nodepool: default-pool
+  affinity:
+    # Native Kubernetes nodeAffinity for all init jobs, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
 
   ## optional, you can provide your own zookeeper metadata store for other components
   # to use this, you should explicit set components.zookeeper to false
@@ -1303,13 +1347,17 @@ standalone:
     anti_affinity: false
     anti_affinity_topology_key: kubernetes.io/hostname
     type: preferredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   appAnnotations: {}
   annotations: {}
   tolerations: []
@@ -1421,13 +1469,17 @@ broker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: preferredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -1747,13 +1799,17 @@ function_worker:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard)
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guarantee
     type: preferredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # priorityClassName: high-priority-nonpreempting
@@ -1867,13 +1923,17 @@ proxy:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: requiredDuringSchedulingIgnoredDuringExecution
-    # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-    # node_affinity:
-    #   matchExpression:
-    #     key: <node-label-key>
-    #     operator: In
-    #     values:
-    #       - <label-value>
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -2040,15 +2100,18 @@ toolset:
   # priorityClassName: high-priority-nonpreempting
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
-  # Pin this component's pods to nodes whose labels match. Unset by default (no node affinity is applied).
-  # This component runs a single replica, so pod anti-affinity is not applicable; only node_affinity is supported.
-  # affinity:
-  #   node_affinity:
-  #     matchExpression:
-  #       key: <node-label-key>
-  #       operator: In
-  #       values:
-  #         - <label-value>
+  affinity:
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # annotations for the app (statefulset/deployment)
   appAnnotations: {}
   annotations: {}
@@ -2334,6 +2397,18 @@ pulsar_manager:
   # nodeSelector:
   # cloud.google.com/gke-nodepool: default-pool
   # priorityClassName: high-priority-nonpreempting
+  affinity:
+    # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+    # Unset by default, so no node affinity is applied. See
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    nodeAffinity: {}
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #       - matchExpressions:
+    #           - key: node-pool
+    #             operator: In
+    #             values:
+    #               - pulsar-pool
   # set topologySpreadConstraint to deploy pods across different zones
   topologySpreadConstraints: []
   # annotations for the app (statefulset/deployment)
@@ -2436,6 +2511,18 @@ dekaf:
     nodeSelector: {}
     tolerations: []
     # priorityClassName: high-priority-nonpreempting
+    affinity:
+      # Native Kubernetes nodeAffinity for this component, passed through verbatim.
+      # Unset by default, so no node affinity is applied. See
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+      nodeAffinity: {}
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #       - matchExpressions:
+      #           - key: node-pool
+      #             operator: In
+      #             values:
+      #               - pulsar-pool
     extraVolumes: []
     extraVolumeMounts: []
     extraContainers: []


### PR DESCRIPTION
Fixes #247.

### Motivation

Users running on clusters with multiple node pools (e.g. GKE) need to pin Pulsar
components to specific nodes. Today the chart exposes `nodeSelector` and pod
anti-affinity, but no `nodeAffinity`, forcing workarounds like cordoning nodes.

This revives the work from #349 (by @MonicaMagoniCom), whose source branch was
deleted before it could be merged, and extends it to every other scheduled
workload in the chart.

### Modifications

Adds an optional `affinity.nodeAffinity` to every pod-producing template. The
value is passed through to the pod spec verbatim via `toYaml | nindent`, so it
is native Kubernetes node affinity syntax — the same convention the chart's
adjacent scheduling knobs (`nodeSelector`, `tolerations`,
`topologySpreadConstraints`) already follow. Unset by default, so no node
affinity is applied and existing deployments are unaffected. It renders as a
sibling of the chart's own `podAntiAffinity` rather than replacing it.

```yaml
broker:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: cloud.google.com/gke-nodepool
                operator: In
                values:
                  - pulsar-pool
```

The value paths, one per component:

| Value path | Templates |
| --- | --- |
| `zookeeper.affinity.nodeAffinity` | `zookeeper-statefulset.yaml`, `zookeeper-statefulset-upgrade.yaml` |
| `bookkeeper.affinity.nodeAffinity` | `bookkeeper-statefulset.yaml` |
| `broker.affinity.nodeAffinity` | `broker-statefulset.yaml`, `broker-statefulset-upgrade.yaml` |
| `proxy.affinity.nodeAffinity` | `proxy-statefulset.yaml` |
| `autorecovery.affinity.nodeAffinity` | `autorecovery-statefulset.yaml` |
| `function_worker.affinity.nodeAffinity` | `function-worker-statefulset.yaml` |
| `toolset.affinity.nodeAffinity` | `toolset-statefulset.yaml` |
| `standalone.affinity.nodeAffinity` | `standalone-deployment.yaml` |
| `oxia.server.affinity.nodeAffinity` | `oxia-server-statefulset.yaml` |
| `oxia.coordinator.affinity.nodeAffinity` | `oxia-coordinator-deployment.yaml` |
| `pulsar_manager.affinity.nodeAffinity` | `pulsar-manager-statefulset.yaml` |
| `dekaf.deployment.affinity.nodeAffinity` | `dekaf-deployment.yaml` |
| `pulsar_metadata.affinity.nodeAffinity` | `bookkeeper-cluster-initialize.yaml`, `pulsar-cluster-initialize.yaml`, `pulsar-manager-cluster-initialize.yaml` |
| `auth.authentication.jwt.generateSecrets.affinity.nodeAffinity` | `jwt-secret-init.yaml` |

Alongside the node affinity, the broker and zookeeper `sts-cleanup` hook Jobs
pick up the scheduling knobs their component StatefulSets already honour —
`imagePullSecrets`, `nodeSelector`, `priorityClassName`, `tolerations`,
`topologySpreadConstraints`, and container `imagePullPolicy` — so a cluster that
reserves nodes for Pulsar does not leave these hooks unschedulable. They
deliberately get **no** pod anti-affinity: they are short-lived single-shot
`kubectl` pods, spreading them across nodes buys nothing, and inheriting
zookeeper's default *required* rule would make the `pre-upgrade` hook
unschedulable on a 3-node cluster and hang `helm upgrade`.

`.ci/templates-all-values.yaml` and its patch1 overlay set `nodeAffinity` on
every component so the CI sweep exercises the passthrough, and the README gains
a node-pinning example next to the existing anti-affinity note.

### Verifying this change

- `helm template test charts/pulsar` with **default values** is byte-identical to
  master apart from the two intended cleanup-Job additions and the chart's
  randomly generated secrets — in particular there are zero scheduling-related
  differences, so default behavior is genuinely unchanged.
- `helm lint charts/pulsar` clean.
- `kubeconform -strict` passes on k8s 1.25 / 1.31 / 1.36 across default values
  and all 19 `.ci/clusters/*.yaml` configs, both with and without `nodeAffinity`
  set on every component — 120 combinations — plus both
  `templates-all-values.yaml` renders at 1.36.
- Every one of the 18 pod-producing templates was confirmed to render its own
  component's `nodeAffinity`, with the expected shape and no copy-paste
  crossover, and to keep `nodeAffinity`/`podAntiAffinity` as siblings under a
  single `affinity:` mapping.
- The `jwt-secret-init` guard was checked across all four combinations of
  `nodeAffinity` set/unset × `anti_affinity` true/false, including the case where
  neither renders and no `affinity:` key is emitted at all.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (does it add or upgrade a dependency)
- [x] The public API: new `affinity.nodeAffinity` value per component; additive
      and unset by default
- [ ] The schema
- [ ] The default values of configurations
- [ ] The wire protocol
- [ ] The rest endpoints
- [ ] The admin cli options
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed` — documented inline in `values.yaml` and in the README
