### PR TITLE
Configure certificates subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,35 @@ helm upgrade -n <namespace> -f values.yaml <pulsar-release-name> apachepulsar/pu
 
 For more detailed information, see our [Upgrading](http://pulsar.apache.org/docs/helm-upgrade/) guide.
 
+## Upgrading to Helm chart version 4.8.0
+
+### X.509 certificate subject
+
+In order to define the various parameters of the X.509 certificate subject, you need to update `tls.common` values :
+
+```
+# before
+tls:
+  common:
+    organization:
+      - pulsar
+# after
+tls:
+  common:
+    subject:
+      organizations:
+        - pulsar
+      # countries: []
+      # organizationalUnits: []
+      # localities: []
+      # provinces: []
+      # streetAddresses: []
+      # postalCodes: []
+      # serialNumber: ""
+```
+
+The upgrade will fail if you still use the old value `tls.common.organization`.
+
 ## Upgrading to Helm chart version 4.6.0
 
 ### ZooKeeper and Broker Services split into ClusterIP + headless

--- a/charts/pulsar/templates/_certs.tpl
+++ b/charts/pulsar/templates/_certs.tpl
@@ -87,9 +87,13 @@ spec:
 {{- end }}
   duration: "{{ .root.Values.tls.common.duration }}"
   renewBefore: "{{ .root.Values.tls.common.renewBefore }}"
+{{- if hasKey .root.Values.tls.common "organization" -}}
+{{- fail "tls.common.organization is no longer supported. Please configure tls.common.subject instead" -}}
+{{- end -}}
+{{- if .root.Values.tls.common.subject }}
   subject:
-    organizations:
-{{ toYaml .root.Values.tls.common.organization | indent 4 }}
+{{ toYaml .root.Values.tls.common.subject | indent 4 }}
+{{- end }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" .root }}-{{ .componentConfig.component }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -268,8 +268,9 @@ tls:
     duration: 2160h
     # 15d
     renewBefore: 360h
-    organization:
-      - pulsar
+    subject:
+      organizations:
+        - pulsar
     keySize: 4096
     keyAlgorithm: RSA
     keyEncoding: PKCS8

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -271,6 +271,13 @@ tls:
     subject:
       organizations:
         - pulsar
+      # countries: []
+      # organizationalUnits: []
+      # localities: []
+      # provinces: []
+      # streetAddresses: []
+      # postalCodes: []
+      # serialNumber: ""
     keySize: 4096
     keyAlgorithm: RSA
     keyEncoding: PKCS8


### PR DESCRIPTION
### Motivation

Currently only certificates subject organizations is configurable.

This PR allow to configure full subject properties.

### Modifications

Move `tls.common.organization` to `tls.common.subject.organizations`.

Fail if  `tls.common.organization` is still used.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
