### PR TITLE
fix: don't render PodMonitor and HPA for disabled components

### DIFF
--- a/charts/pulsar/templates/autorecovery-podmonitor.yaml
+++ b/charts/pulsar/templates/autorecovery-podmonitor.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# deploy autorecovery PodMonitor only when `$.Values.autorecovery.podMonitor.enabled` is true
-{{- if and $.Values.autorecovery.podMonitor.enabled (not $.Values.standalone.enabled) }}
+# deploy autorecovery PodMonitor only when the autorecovery component and `$.Values.autorecovery.podMonitor.enabled` are both enabled
+{{- if and $.Values.components.autorecovery $.Values.autorecovery.podMonitor.enabled (not $.Values.standalone.enabled) }}
 {{- include "pulsar.podMonitor" (list . "autorecovery" (printf "component: %s" .Values.autorecovery.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-podmonitor.yaml
+++ b/charts/pulsar/templates/bookkeeper-podmonitor.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# deploy bookkeeper PodMonitor only when `$.Values.bookkeeper.podMonitor.enabled` is true
-{{- if and $.Values.bookkeeper.podMonitor.enabled (not $.Values.standalone.enabled) }}
+# deploy bookkeeper PodMonitor only when the bookkeeper component and `$.Values.bookkeeper.podMonitor.enabled` are both enabled
+{{- if and $.Values.components.bookkeeper $.Values.bookkeeper.podMonitor.enabled (not $.Values.standalone.enabled) }}
 {{- include "pulsar.podMonitor" (list . "bookkeeper" (printf "component: %s" .Values.bookkeeper.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/broker-hpa.yaml
+++ b/charts/pulsar/templates/broker-hpa.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if and .Values.broker.autoscaling.enabled (not .Values.standalone.enabled) }}
+{{- if and .Values.components.broker .Values.broker.autoscaling.enabled (not .Values.standalone.enabled) }}
 {{- if (semverCompare "<1.23-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}

--- a/charts/pulsar/templates/broker-podmonitor.yaml
+++ b/charts/pulsar/templates/broker-podmonitor.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# deploy broker PodMonitor only when `$.Values.broker.podMonitor.enabled` is true
-{{- if and $.Values.broker.podMonitor.enabled (not $.Values.standalone.enabled) }}
+# deploy broker PodMonitor only when the broker component and `$.Values.broker.podMonitor.enabled` are both enabled
+{{- if and $.Values.components.broker $.Values.broker.podMonitor.enabled (not $.Values.standalone.enabled) }}
 {{- include "pulsar.podMonitor" (list . "broker" (printf "component: %s" .Values.broker.component)) }}
 {{- end }}

--- a/charts/pulsar/templates/proxy-hpa.yaml
+++ b/charts/pulsar/templates/proxy-hpa.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.proxy.autoscaling.enabled }}
+{{- if and .Values.components.proxy .Values.proxy.autoscaling.enabled }}
 {{- if (semverCompare "<1.23-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}

--- a/charts/pulsar/templates/proxy-podmonitor.yaml
+++ b/charts/pulsar/templates/proxy-podmonitor.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# deploy proxy PodMonitor only when `$.Values.proxy.podMonitor.enabled` is true
-{{- if $.Values.proxy.podMonitor.enabled }}
+# deploy proxy PodMonitor only when the proxy component and `$.Values.proxy.podMonitor.enabled` are both enabled
+{{- if and $.Values.components.proxy $.Values.proxy.podMonitor.enabled }}
 {{- include "pulsar.podMonitor" (list . "proxy" (printf "component: %s" .Values.proxy.component) "sts-http") }}
 {{- end }}


### PR DESCRIPTION
Fixes #716

### Motivation

The `PodMonitor` (or `VMPodScrape`, when `victoria-metrics-k8s-stack` is enabled) for the proxy, broker, bookkeeper and autorecovery components was guarded only by `<component>.podMonitor.enabled`, which defaults to `true`. As a result it was rendered even when the component itself was disabled via `components.*=false`, leaving scrape configs whose selectors match no pods — harmless to Prometheus, but permanent drift in GitOps setups and empty targets/series in dashboards. Disabling a component required disabling it twice.

`proxy-hpa.yaml` and `broker-hpa.yaml` had the same missing guard. That case is rarer, since it also requires `autoscaling.enabled=true`, but the consequence is worse: the HPA targets a StatefulSet that was never created, so the HPA controller sits at `ScalingActive=False` / `FailedGetScale` and emits warning events continuously.

The zookeeper, function-worker and oxia pod monitors already check `components.*`, as does every other template belonging to these four components (statefulset, service, configmap, pdb, service-account) — these six were the outliers.

### Modifications

Added the missing `components.*` condition to six templates, keeping the existing `standalone.enabled` checks where present:

| Template | New guard |
|---|---|
| `proxy-podmonitor.yaml` | `and $.Values.components.proxy $.Values.proxy.podMonitor.enabled` |
| `broker-podmonitor.yaml` | `and $.Values.components.broker $.Values.broker.podMonitor.enabled (not $.Values.standalone.enabled)` |
| `bookkeeper-podmonitor.yaml` | `and $.Values.components.bookkeeper $.Values.bookkeeper.podMonitor.enabled (not $.Values.standalone.enabled)` |
| `autorecovery-podmonitor.yaml` | `and $.Values.components.autorecovery $.Values.autorecovery.podMonitor.enabled (not $.Values.standalone.enabled)` |
| `proxy-hpa.yaml` | `and .Values.components.proxy .Values.proxy.autoscaling.enabled` |
| `broker-hpa.yaml` | `and .Values.components.broker .Values.broker.autoscaling.enabled (not .Values.standalone.enabled)` |

The now-stale `# deploy <component> PodMonitor only when ... is true` comment above each pod monitor guard was updated to match.

No new tests: the chart has no harness that can assert a resource is *absent* (the template checks in CI are kubeconform schema validation over rendered output), and adding one would be a larger change than the fix itself.

### Verifying this change

Before the change, both of these rendered resources for components that were switched off; after it, both render nothing:

```console
$ helm template t charts/pulsar \
    --set components.proxy=false --set components.broker=false \
    --set components.bookkeeper=false --set components.autorecovery=false \
    --set components.zookeeper=false \
    --set proxy.autoscaling.enabled=true --set broker.autoscaling.enabled=true \
  | awk '/^# Source:/{s=$3} /^kind: (PodMonitor|VMPodScrape|HorizontalPodAutoscaler)/{print $2, s}'
```

No behavior change with default values — all five pod monitors still render, and both HPAs still render with `autoscaling.enabled=true`.

Also verified locally: `helm lint` clean; the CI "all features enabled" renders (`.ci/templates-all-values.yaml`, and with the `patch1` overlay, at `--kube-version 1.36.0`) and the `.ci/clusters/values-standalone.yaml` scenario all render successfully.

Note this is technically a behavior change for anyone who sets `components.<component>=false` and relies on the stray PodMonitor/HPA being present — unlikely, but may be worth a line in the release notes.

- [x] Make sure that the change passes the CI checks.
